### PR TITLE
Update push_secrets.sh to use hcp instead of vlt

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,20 @@ Use the arrow keys to navigate: ↓ ↑ → ←
   ▸ sistema
 ```
 
+### Copying secrets from the vault to local
+
 - Copy secrets to a `.env` file
 
 ```bash
 ./setup_secrets.sh
+```
+
+### Sending all local secrets to the vault (warning: this overwrites all secrets)
+
+- Push secrets from `.env` file to HashiCorp Vault
+
+```bash
+./push_secrets.sh
 ```
 
 ## Version Control Guide

--- a/push_secrets.sh
+++ b/push_secrets.sh
@@ -21,7 +21,7 @@ fi
 
 # Fetch all existing secret keys and delete them
 echo "Fetching and deleting all existing secrets..."
-SECRET_KEYS=$(hcp vault-secrets secrets list --format=json | grep -Eo '"([^"]*)"\s*:\s*"([^"]*)"' | sed -E 's/^"([^"]*)"\s*:\s*"([^"]*)"$/\1=\2/' | grep "^name=" | grep -v "@" | sed 's/^name=//')
+SECRET_KEYS=$(hcp vault-secrets secrets list --format=json --app=sistema | grep -Eo '"([^"]*)"\s*:\s*"([^"]*)"' | sed -E 's/^"([^"]*)"\s*:\s*"([^"]*)"$/\1=\2/' | grep "^name=" | grep -v "@" | sed 's/^name=//')
 
 for secret_key in $SECRET_KEYS; do
     echo "Deleting secret with name $secret_key"

--- a/push_secrets.sh
+++ b/push_secrets.sh
@@ -21,7 +21,7 @@ fi
 
 # Fetch all existing secret keys and delete them
 echo "Fetching and deleting all existing secrets..."
-SECRET_KEYS=$(hcp vault-secrets secrets list --format=json --app=sistema | grep -Eo '"([^"]*)"\s*:\s*"([^"]*)"' | sed -E 's/^"([^"]*)"\s*:\s*"([^"]*)"$/\1=\2/' | grep "^name=" | grep -v "@" | sed 's/^name=//')
+SECRET_KEYS=$(hcp vault-secrets secrets list --format=json --app=sistema | grep -Eo '"([^"]*)"\s*:\s*"([^"]*)"' | sed -E 's/^"([^"]*)"\s*:\s*"([^"]*)"$/\1=\2/' | grep '^\(name=\|"name":\)'| grep -v "@" | sed 's/^"name": "\(.*\)"$/\1/; s/^name=\(.*\)$/\1/')
 
 for secret_key in $SECRET_KEYS; do
     echo "Deleting secret with name $secret_key"


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Modify push_secrets.sh to use hcp instead of vlt](https://www.notion.so/uwblueprintexecs/Modify-push_secrets-sh-to-use-hcp-instead-of-vlt-bd8b498784a04ec19c3c052c565c209f)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Updated all `vlt` commands to `hcp` commands

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Create a test key/value secret within the .env file
2. Run `./push_secrets.sh`
3. Check HashiCorp to ensure the secret was created
4. Change the value of the test key/value secret within the .env file
5. Run `./push_secrets.sh`
6. Check Hashicorp to ensure the secret was deleted and re-created with the changed value
7. Remove the test key/value secret within the .env file
8. Run `./push_secrets.sh`
9. Check Hashicorp to ensure the secret was deleted

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
