### PR TITLE
Modify setup_secrets.sh to use hcp instead of vlt

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ npm install
 - In the folder where you cloned the Sistema repository, log into Vault
 
 ```bash
-vlt login
+hcp auth login
 ```
 
 - Configure the Vault Command Line Interface
 
 ```bash
-vlt config init
+hcp profile init
 ```
 
 - Select the `sistema` Organization and Project

--- a/setup_secrets.sh
+++ b/setup_secrets.sh
@@ -5,13 +5,13 @@ ENV_FILE=".env"
 
 # Login to Vault
 echo "Logging into Vault..."
-hcp auth login 
+hcp auth login
 if [ $? -ne 0 ]; then
 echo "Failed to login to Vault. Please check your credentials."
 exit 1
 fi
 
-hcp profile init 
+hcp profile init
 
 # Check if .env file exists and delete it if it does
 if [ -f "$ENV_FILE" ]; then

--- a/setup_secrets.sh
+++ b/setup_secrets.sh
@@ -5,13 +5,13 @@ ENV_FILE=".env"
 
 # Login to Vault
 echo "Logging into Vault..."
-vlt login
+hcp auth login 
 if [ $? -ne 0 ]; then
 echo "Failed to login to Vault. Please check your credentials."
 exit 1
 fi
 
-vlt config init
+hcp profile init 
 
 # Check if .env file exists and delete it if it does
 if [ -f "$ENV_FILE" ]; then
@@ -19,7 +19,7 @@ if [ -f "$ENV_FILE" ]; then
 fi
 
 # Fetch all secret keys from Vault
-SECRET_KEYS=$(vlt secrets list -format=json | grep -Eo '"([^"]*)"\s*:\s*"([^"]*)"' | sed -E 's/^"([^"]*)"\s*:\s*"([^"]*)"$/\1=\2/' | grep "^name=" | grep -v "@" | sed 's/^name=//')
+SECRET_KEYS=$(hcp vault-secrets secrets list --format=json | grep -Eo '"([^"]*)"\s*:\s*"([^"]*)"' | sed -E 's/"([^"]+)": "([^"]+)"/\1=\2/g' | grep "^name=" | grep -v "@" | sed 's/^name=//')
 
 if [ $? -ne 0 ] || [ -z "$SECRET_KEYS" ]; then
     echo "Failed to retrieve secret keys from Vault."
@@ -28,7 +28,7 @@ fi
 
 # Iterate over each secret key and fetch the secret value
 for key in $SECRET_KEYS; do
-    SECRET_VALUE=$(vlt secrets get --plaintext $key 2>/dev/null)
+    SECRET_VALUE=$(hcp vault-secrets secrets open $key | grep "Value:" | sed -E 's/Value:\s*(.*)/\1/; s/^[ \t]+|[ \t]+$//g' 2>/dev/null)
 
     if [ $? -ne 0 ] || [ -z "$SECRET_VALUE" ]; then
         echo "Failed to retrieve secret for key $key. Skipping."


### PR DESCRIPTION
# Notion ticket link

<!-- Please replace with your ticket's URL -->

[Modify setup_secrets.sh to use hcp instead of vlt](https://www.notion.so/uwblueprintexecs/Modify-setup_secrets-sh-to-use-hcp-instead-of-vlt-70698a25079249afb78f392ff713ea2c?pvs=4)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- the script should download all secrets from the hashiCorp vault to a .env file. 
- updated it to use hcp instead of vlt 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. run the script to make sure it correctly creates the .env again and consists of all secrets from HashiCorp 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
