### PR TITLE
Subscribable ICS feed

### DIFF
--- a/app/api/getAbsences/absences.ts
+++ b/app/api/getAbsences/absences.ts
@@ -1,0 +1,72 @@
+import { prisma } from '@utils/prisma';
+
+export interface AbsenceWithRelations {
+  lessonDate: Date;
+  lessonPlan: string | null;
+  reasonOfAbsence: string;
+  notes: string | null;
+  absentTeacher: {
+    firstName: string;
+    lastName: string;
+    email: string;
+  };
+  substituteTeacher: {
+    firstName: string;
+    lastName: string;
+    email: string;
+  } | null;
+  location: {
+    name: string;
+    abbreviation: string;
+  };
+  subject: {
+    name: string;
+    abbreviation: string;
+  };
+}
+
+export const getAbsencesFromDatabase = async (): Promise<
+  AbsenceWithRelations[]
+> => {
+  try {
+    const absences: AbsenceWithRelations[] = await prisma.absence.findMany({
+      select: {
+        lessonDate: true,
+        subject: {
+          select: {
+            name: true,
+            abbreviation: true,
+          },
+        },
+        lessonPlan: true,
+        reasonOfAbsence: true,
+        notes: true,
+        absentTeacher: {
+          select: {
+            firstName: true,
+            lastName: true,
+            email: true,
+          },
+        },
+        substituteTeacher: {
+          select: {
+            firstName: true,
+            lastName: true,
+            email: true,
+          },
+        },
+        location: {
+          select: {
+            name: true,
+            abbreviation: true,
+          },
+        },
+      },
+    });
+
+    return absences;
+  } catch (err) {
+    console.error('Error fetching absences:', err);
+    throw err;
+  }
+};

--- a/app/api/getAbsences/route.ts
+++ b/app/api/getAbsences/route.ts
@@ -1,67 +1,9 @@
-import { prisma } from '@utils/prisma';
 import { NextResponse } from 'next/server';
-
-export interface AbsenceWithRelations {
-  lessonDate: Date;
-  lessonPlan: string | null;
-  reasonOfAbsence: string;
-  notes: string | null;
-  absentTeacher: {
-    firstName: string;
-    lastName: string;
-    email: string;
-  };
-  substituteTeacher: {
-    firstName: string;
-    lastName: string;
-    email: string;
-  } | null;
-  location: {
-    name: string;
-    abbreviation: string;
-  };
-  subject: {
-    name: string;
-    abbreviation: string;
-  };
-}
+import { AbsenceWithRelations, getAbsencesFromDatabase } from './absences';
 
 export async function GET() {
   try {
-    const absences: AbsenceWithRelations[] = await prisma.absence.findMany({
-      select: {
-        lessonDate: true,
-        subject: {
-          select: {
-            name: true,
-            abbreviation: true,
-          },
-        },
-        lessonPlan: true,
-        reasonOfAbsence: true,
-        notes: true,
-        absentTeacher: {
-          select: {
-            firstName: true,
-            lastName: true,
-            email: true,
-          },
-        },
-        substituteTeacher: {
-          select: {
-            firstName: true,
-            lastName: true,
-            email: true,
-          },
-        },
-        location: {
-          select: {
-            name: true,
-            abbreviation: true,
-          },
-        },
-      },
-    });
+    const absences: AbsenceWithRelations[] = await getAbsencesFromDatabase();
 
     if (!absences.length) {
       return NextResponse.json({ events: [] }, { status: 200 });

--- a/app/api/ics/[id]/ics.ts
+++ b/app/api/ics/[id]/ics.ts
@@ -1,9 +1,10 @@
 import { EventAttributes, createEvents } from 'ics';
 import { AbsenceWithRelations } from '../../getAbsences/absences';
 
+const CALENDAR_NAME: string = 'Sistema Absences';
+
 export const convertAbsenceToICSEvent = (
-  absence: AbsenceWithRelations,
-  calendarName: string
+  absence: AbsenceWithRelations
 ): EventAttributes => {
   const substituteTeacherString = absence.substituteTeacher
     ? `(${absence.substituteTeacher.firstName} ${absence.substituteTeacher.lastName[0]})`
@@ -25,7 +26,7 @@ export const convertAbsenceToICSEvent = (
     title: `${absence.subject.name}: ${absence.absentTeacher.firstName} ${absence.absentTeacher.lastName[0]}${substituteTeacherString}`,
     description: `Subject: ${absence.subject.name}\nLesson Plan: ${lessonString}${notesLine}`,
     location: absence.location.name,
-    calName: calendarName,
+    calName: CALENDAR_NAME,
   };
 };
 

--- a/app/api/ics/[id]/ics.ts
+++ b/app/api/ics/[id]/ics.ts
@@ -1,0 +1,45 @@
+import { EventAttributes, createEvents } from 'ics';
+import { AbsenceWithRelations } from '../../getAbsences/absences';
+
+export const convertAbsenceToICSEvent = (
+  absence: AbsenceWithRelations,
+  calendarName: string
+): EventAttributes => {
+  const substituteTeacherString = absence.substituteTeacher
+    ? `(${absence.substituteTeacher.firstName} ${absence.substituteTeacher.lastName[0]})`
+    : '';
+  const lessonString = absence.lessonPlan || 'Lesson Plan Not Submitted';
+  const notesLine = absence.notes ? `\nNotes: ${absence.notes}` : '';
+
+  const startDate = new Date(absence.lessonDate);
+  const endDate = new Date(absence.lessonDate);
+  endDate.setDate(startDate.getDate() + 1);
+
+  return {
+    start: [
+      startDate.getFullYear(),
+      startDate.getMonth() + 1,
+      startDate.getDate(),
+    ],
+    end: [endDate.getFullYear(), endDate.getMonth() + 1, endDate.getDate()],
+    title: `${absence.subject.name}: ${absence.absentTeacher.firstName} ${absence.absentTeacher.lastName[0]}${substituteTeacherString}`,
+    description: `Subject: ${absence.subject.name}\nLesson Plan: ${lessonString}${notesLine}`,
+    location: absence.location.name,
+    calName: calendarName,
+  };
+};
+
+export const createCalendarFile = (
+  events: EventAttributes[]
+): Promise<File> => {
+  return new Promise((resolve, reject) => {
+    createEvents(events, (error, value) => {
+      if (error) {
+        console.error('Error creating events:', error);
+        reject(error);
+      } else {
+        resolve(new File([value], 'Absences.ics', { type: 'text/calendar' }));
+      }
+    });
+  });
+};

--- a/app/api/ics/[id]/route.ts
+++ b/app/api/ics/[id]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createCalendarFile } from './ics';
+import { getAbsencesFromDatabase } from '../../getAbsences/absences';
+import { convertAbsenceToICSEvent } from './ics';
+
+const getICSFileById = async (id: string) => {
+  console.log('Getting ICS file for id:', id);
+  const absences = await getAbsencesFromDatabase();
+  const events = absences.map(convertAbsenceToICSEvent);
+  return createCalendarFile(events);
+};
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const { id } = params;
+  console.log('ICS file requested:', id);
+
+  if (!id || typeof id !== 'string') {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+
+  try {
+    const icsFile = await getICSFileById(id);
+    if (!icsFile) {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 });
+    }
+
+    // convert file to response
+    const buffer = await icsFile.arrayBuffer();
+    const blob = new Blob([buffer], { type: 'text/calendar' });
+
+    return new Response(blob, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/calendar',
+        'Content-Disposition': `attachment; filename=${id}`,
+      },
+    });
+  } catch (error) {
+    console.error('Error fetching ICS file:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -4,7 +4,7 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import { Box, Flex, useToast, useTheme } from '@chakra-ui/react';
 import { EventInput, EventContentArg } from '@fullcalendar/core';
-import { AbsenceWithRelations } from '../../app/api/getAbsences/route';
+import { AbsenceWithRelations } from '../../app/api/getAbsences/absences';
 import Sidebar from '../components/CalendarSidebar';
 import CalendarHeader from '../components/CalendarHeader';
 import { Global } from '@emotion/react';

--- a/src/pages/ics.tsx
+++ b/src/pages/ics.tsx
@@ -1,65 +1,12 @@
-import { EventAttributes, createEvents } from 'ics';
 import React, { useState } from 'react';
-import { AbsenceWithRelations } from '../../app/api/getAbsences/route';
+import { createCalendarFile } from '../../app/api/ics/[id]/ics';
+import { AbsenceWithRelations } from '../../app/api/getAbsences/absences';
+import { convertAbsenceToICSEvent } from '../../app/api/ics/[id]/ics';
 
 export default function CalendarDownload() {
   const [error, setError] = useState<string | null>(null);
 
-  const searchAbsences = async (): Promise<EventAttributes[]> => {
-    try {
-      const res = await fetch('/api/getAbsences/');
-      if (!res.ok) {
-        throw new Error(`Failed to fetch: ${res.statusText}`);
-      }
-      const data = await res.json();
-      if (!data.events || !Array.isArray(data.events)) {
-        throw new Error('Invalid data format.');
-      }
-      return data.events.map((absence: AbsenceWithRelations) => {
-        const substituteTeacherString = absence.substituteTeacher
-          ? `(${absence.substituteTeacher.firstName} ${absence.substituteTeacher.lastName[0]})`
-          : '';
-        const lessonString = absence.lessonPlan || 'Lesson Plan Not Submitted';
-        const notesLine = absence.notes ? `\nNotes: ${absence.notes}` : '';
-
-        const startDate = new Date(absence.lessonDate);
-        const endDate = new Date(absence.lessonDate);
-        endDate.setDate(startDate.getDate() + 1);
-
-        return {
-          start: [
-            startDate.getFullYear(),
-            startDate.getMonth() + 1,
-            startDate.getDate(),
-          ],
-          end: [
-            endDate.getFullYear(),
-            endDate.getMonth() + 1,
-            endDate.getDate(),
-          ],
-          title: `${absence.subject.name}: ${absence.absentTeacher.firstName} ${absence.absentTeacher.lastName[0]}${substituteTeacherString}`,
-          description: `Subject: ${absence.subject.name}\nLesson Plan: ${lessonString}${notesLine}`,
-          location: absence.location.name,
-        };
-      });
-    } catch (err) {
-      console.error('Error fetching absences:', err);
-      throw err;
-    }
-  };
-
-  const createCalendarFile = (events: EventAttributes[]): Promise<File> => {
-    return new Promise((resolve, reject) => {
-      createEvents(events, (error, value) => {
-        if (error) {
-          console.error('Error creating events:', error);
-          reject(error);
-        } else {
-          resolve(new File([value], 'Absences.ics', { type: 'text/calendar' }));
-        }
-      });
-    });
-  };
+  const CALENDAR_NAME: string = 'Sistema Absences';
 
   const downloadFile = (file: File) => {
     const url = URL.createObjectURL(file);
@@ -77,8 +24,21 @@ export default function CalendarDownload() {
     setError(null);
 
     try {
-      const events = await searchAbsences();
-      const file = await createCalendarFile(events);
+      const res = await fetch('/api/getAbsences/');
+
+      if (!res.ok) {
+        throw new Error(`Failed to fetch: ${res.statusText}`);
+      }
+      const data = await res.json();
+      if (!data.events || !Array.isArray(data.events)) {
+        throw new Error('Invalid data format.');
+      }
+
+      const icsEvents = data.events.map((eventData: AbsenceWithRelations) =>
+        convertAbsenceToICSEvent(eventData, CALENDAR_NAME)
+      );
+
+      const file = await createCalendarFile(icsEvents);
       downloadFile(file);
     } catch (error) {
       console.error('Error during download process:', error);

--- a/src/pages/ics.tsx
+++ b/src/pages/ics.tsx
@@ -1,12 +1,9 @@
 import React, { useState } from 'react';
 import { createCalendarFile } from '../../app/api/ics/[id]/ics';
-import { AbsenceWithRelations } from '../../app/api/getAbsences/absences';
 import { convertAbsenceToICSEvent } from '../../app/api/ics/[id]/ics';
 
 export default function CalendarDownload() {
   const [error, setError] = useState<string | null>(null);
-
-  const CALENDAR_NAME: string = 'Sistema Absences';
 
   const downloadFile = (file: File) => {
     const url = URL.createObjectURL(file);
@@ -34,9 +31,7 @@ export default function CalendarDownload() {
         throw new Error('Invalid data format.');
       }
 
-      const icsEvents = data.events.map((eventData: AbsenceWithRelations) =>
-        convertAbsenceToICSEvent(eventData, CALENDAR_NAME)
-      );
+      const icsEvents = data.events.map(convertAbsenceToICSEvent);
 
       const file = await createCalendarFile(icsEvents);
       downloadFile(file);


### PR DESCRIPTION
# Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket Name](https://www.notion.so/uwblueprintexecs/Host-ICS-file-802faa048878454aa16d0339eef620ab?pvs=4)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Adds a subscribable ICS calendar
-  You can replace "calendar.ics" with any name! I think a good bet would be in the future, we return a calendar based on the name of the file requested, or enforce a path like api/ics/<some hard to guess ID>/calendar.ics
- I have it set up so that the name of the ics file requested is a parameter when actually generating the file, so hopefully we can use that when building the calendar.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Try subscribing to /api/ics/calendar.ics and verify that it works. You will need to go to Google Calendar and try subscribing to this URL, making sure to use a deployed build (not localhost)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Make sure things are working as expected on Google Calendar!

## Checklist

- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
