### PR TITLE
Added cron config file

### DIFF
--- a/.github/workflows/cron-job.yml
+++ b/.github/workflows/cron-job.yml
@@ -1,0 +1,15 @@
+name: Send Email reminders for missing lessons
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Runs every day at midnight UTC
+  workflow_dispatch:
+
+jobs:
+  call-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call API
+        run: |
+          date # Add date logging
+          curl -X GET "https://sistema-prod.vercel.app/api/reminders"

--- a/.github/workflows/cron-job.yml
+++ b/.github/workflows/cron-job.yml
@@ -1,15 +1,15 @@
-name: Send Email reminders for missing lessons
+name: Send Email Reminders for Missing Lessons
 
 on:
   schedule:
-    - cron: "0 0 * * *" # Runs every day at midnight UTC
+    - cron: "0 0 * * *" # Runs every day at 00:00 UTC
   workflow_dispatch:
 
 jobs:
   call-api:
     runs-on: ubuntu-latest
     steps:
-      - name: Call API
-        run: |
-          date # Add date logging
-          curl -X GET "https://sistema-prod.vercel.app/api/reminders"
+      - name: Log current time
+        run: date -u  # Logs the current UTC time
+      - name: Call reminders API
+        run: curl -X GET "https://sistema-prod.vercel.app/api/reminders"


### PR DESCRIPTION
# Notion Ticket

[Schedule Email Reminders](https://www.notion.so/uwblueprintexecs/Schedule-Email-Reminders-03dce3fb03154254aaf632f06e8d9379?pvs=4)

## Summary & Review Focus

<!-- Briefly describe the implementation, key changes, and areas needing review -->
1. The API to send reminders was already added in previous pr
2. Added the yml file to add the configuration for the crown jobs to run at 12 am UTC every day.
## Testing Instructions

1. Merge the branch and then at 12 am UTC, open github actions and check for the job runs 
2. Another way to test is to run the corn manually by going to github actions and check if the emails were sent or not

## Checklist

- [x] PR title is descriptive and in imperative tense
- [x] Commit messages are descriptive, atomic, and follow best practices
- [x] Linter(s) have been run
- [x] Requested reviews from the PL and relevant team members
