### PR TITLE
Add Busy badge to calendar days with events and adjust spacing

### DIFF
--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -66,6 +66,7 @@ const Calendar: React.FC = () => {
     location: absenceData.location.name,
     subjectId: absenceData.subject.id,
     locationId: absenceData.location.id,
+    isClaimed: absenceData.isClaimed || false,
   });
 
   const handleAddAbsence = async (
@@ -218,6 +219,90 @@ const Calendar: React.FC = () => {
     setFilteredEvents(filtered);
   }, [searchQuery, events]);
 
+  // Instead, use dayCellDidMount to directly add badges
+  const dayCellDidMount = useCallback(
+    (info: { el: HTMLElement; date: Date }) => {
+      // Check if there are events on this date
+      const hasEventsOnDate = events.some((event) => {
+        if (!event.start) return false;
+
+        const eventDate = new Date(event.start as string);
+        return eventDate.toDateString() === info.date.toDateString();
+      });
+
+      console.log(
+        `Date: ${info.date.toDateString()}, Has events: ${hasEventsOnDate}`
+      );
+
+      if (hasEventsOnDate) {
+        // Create the badge container with the updated styling
+        const badgeContainer = document.createElement('div');
+        badgeContainer.style.position = 'absolute';
+        badgeContainer.style.top = '15px';
+        badgeContainer.style.right = '6px';
+        badgeContainer.style.display = 'flex';
+        badgeContainer.style.width = '68px';
+        badgeContainer.style.padding = '2px 5px';
+        badgeContainer.style.justifyContent = 'center';
+        badgeContainer.style.alignItems = 'center';
+        badgeContainer.style.gap = '5px';
+        badgeContainer.style.flexShrink = '0';
+        badgeContainer.style.backgroundColor = 'white';
+        badgeContainer.style.borderRadius = '5px';
+        badgeContainer.style.border = '1px solid #D2D2D2';
+        badgeContainer.style.zIndex = '20';
+
+        // Create the SVG icon
+        const iconSvg = document.createElementNS(
+          'http://www.w3.org/2000/svg',
+          'svg'
+        );
+        iconSvg.setAttribute('width', '15');
+        iconSvg.setAttribute('height', '14');
+        iconSvg.setAttribute('viewBox', '0 0 15 14');
+        iconSvg.setAttribute('fill', 'none');
+
+        const path = document.createElementNS(
+          'http://www.w3.org/2000/svg',
+          'path'
+        );
+        path.setAttribute(
+          'd',
+          'M7.49995 4.45977L7.49995 6.90095M7.49995 9.34213L7.49385 9.34213M1.397 6.90095C1.397 3.53039 4.12939 0.798003 7.49996 0.798004C10.8705 0.798004 13.6029 3.53039 13.6029 6.90096C13.6029 10.2715 10.8705 13.0039 7.49995 13.0039C4.12939 13.0039 1.397 10.2715 1.397 6.90095Z'
+        );
+        path.setAttribute('stroke', '#BF3232');
+        path.setAttribute('stroke-width', '1.5');
+        path.setAttribute('stroke-linecap', 'round');
+        path.setAttribute('stroke-linejoin', 'round');
+
+        iconSvg.appendChild(path);
+
+        // Create the text element
+        const textSpan = document.createElement('span');
+        textSpan.textContent = 'Busy';
+        textSpan.style.color = '#141414';
+        textSpan.style.fontFamily = 'Inter, sans-serif';
+        textSpan.style.fontSize = '13px';
+        textSpan.style.fontWeight = '600';
+
+        // Add the icon and text to the badge container
+        badgeContainer.appendChild(iconSvg);
+        badgeContainer.appendChild(textSpan);
+
+        // Add the badge container to the day cell - find the right container
+        const topCell = info.el.querySelector('.fc-daygrid-day-top');
+        if (topCell) {
+          info.el.style.position = 'relative';
+          topCell.appendChild(badgeContainer);
+        } else {
+          info.el.style.position = 'relative';
+          info.el.appendChild(badgeContainer);
+        }
+      }
+    },
+    [events]
+  );
+
   return (
     <>
       <Global
@@ -262,6 +347,10 @@ const Calendar: React.FC = () => {
             margin: ${theme.space[2]} 0;
             border-radius: ${theme.radii.md};
           }
+          .fc-daygrid-day-events {
+            padding-top: 18px !important;
+            margin-top: 0 !important;
+          }
           .fc-event-title {
             overflow: hidden;
             text-overflow: ellipsis;
@@ -278,6 +367,14 @@ const Calendar: React.FC = () => {
             align-items: center;
             justify-content: center;
             }
+          .fc-daygrid-day-top {
+            position: relative !important;
+            z-index: 1;
+          }
+          
+          .fc-daygrid-day-frame {
+            position: relative !important;
+          }
         `}
       />
 
@@ -312,6 +409,7 @@ const Calendar: React.FC = () => {
               height="100%"
               events={filteredEvents}
               eventContent={renderEventContent}
+              dayCellDidMount={dayCellDidMount}
               timeZone="local"
               datesSet={updateMonthYearTitle}
               fixedWeekCount={false}


### PR DESCRIPTION
# Notion Ticket

Add Busy Tags to Maxi Calendar (https://www.notion.so/uwblueprintexecs/Add-Busy-Tags-to-Maxi-Calendar-19b10f3fb1dc80c8b9bfe9cc14567576?pvs=4)

## Summary & Review Focus

<!-- Briefly describe the implementation, key changes, and areas needing review -->
- Literally copied a badge
- adjusted it to every event
- moved current events down to match exactly what figma has
- 
## Testing Instructions
- localhost3000/calendar and scroll
- 
1. <!-- List steps to verify the changes -->
- see it LOL
## Checklist

- [ ] PR title is descriptive and in imperative tense
- [ ] Commit messages are descriptive, atomic, and follow best practices
- [ ] Linter(s) have been run
- [ ] Requested reviews from the PL and relevant team members
