### PR TITLE
Segment Admin Vs. Teacher

### DIFF
--- a/src/components/AbsenceDetails.tsx
+++ b/src/components/AbsenceDetails.tsx
@@ -178,6 +178,7 @@ const AbsenceDetails = ({ isOpen, onClose, event, isAdminMode }) => {
 
             {/* Visibility Tag*/}
             {event.substituteTeacher &&
+              !isAdminMode &&
               (isUserAbsentTeacher || isUserSubstituteTeacher) && (
                 <Flex gap="10px" align="center" textStyle="caption">
                   {isUserAbsentTeacher ? (

--- a/src/components/AbsenceDetails.tsx
+++ b/src/components/AbsenceDetails.tsx
@@ -20,7 +20,7 @@ import { IoEyeOutline } from 'react-icons/io5';
 import AbsenceStatusTag from './AbsenceStatusTag';
 import LessonPlanView from './LessonPlanView';
 
-const AbsenceDetails = ({ isOpen, onClose, event }) => {
+const AbsenceDetails = ({ isOpen, onClose, event, isAdminMode }) => {
   const theme = useTheme();
   const userData = useUserData();
   if (!event) return null;
@@ -28,7 +28,6 @@ const AbsenceDetails = ({ isOpen, onClose, event }) => {
   const userId = userData.id;
   const isUserAbsentTeacher = userId === event.absentTeacher.id;
   const isUserSubstituteTeacher = userId === event.substituteTeacher?.id;
-  const isUserAdmin = userData.role === Role.ADMIN;
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="lg" isCentered>
@@ -43,11 +42,11 @@ const AbsenceDetails = ({ isOpen, onClose, event }) => {
             <AbsenceStatusTag
               isUserAbsentTeacher={isUserAbsentTeacher}
               isUserSubstituteTeacher={isUserSubstituteTeacher}
-              isUserAdmin={isUserAdmin}
+              isAdminMode={isAdminMode}
               substituteTeacherFullName={event.substituteTeacherFullName}
             />
             <Flex position="absolute" right="0">
-              {isUserAdmin && (
+              {isAdminMode && (
                 <IconButton
                   aria-label="Edit Absence"
                   icon={<FiEdit2 size="15px" color={theme.colors.text.body} />}
@@ -56,7 +55,7 @@ const AbsenceDetails = ({ isOpen, onClose, event }) => {
                 />
               )}
 
-              {(isUserAdmin ||
+              {(isAdminMode ||
                 (isUserAbsentTeacher && !event.substituteTeacher)) && (
                 <IconButton
                   aria-label="Delete Absence"
@@ -117,9 +116,10 @@ const AbsenceDetails = ({ isOpen, onClose, event }) => {
                 absentTeacherFirstName={event.absentTeacher.firstName}
                 isUserAbsentTeacher={isUserAbsentTeacher}
                 isUserSubstituteTeacher={isUserSubstituteTeacher}
+                isAdminMode={isAdminMode}
               />
             </Box>
-            {(isUserAdmin || isUserAbsentTeacher) && (
+            {(isAdminMode || isUserAbsentTeacher) && (
               <Box>
                 <Text textStyle="h4" mb="9px">
                   Reason of Absence
@@ -133,7 +133,7 @@ const AbsenceDetails = ({ isOpen, onClose, event }) => {
                 </Box>
               </Box>
             )}
-            {isUserAbsentTeacher && (
+            {isUserAbsentTeacher && !isAdminMode && (
               <Box position="relative">
                 <Text textStyle="h4" mb="9px">
                   Notes
@@ -157,7 +157,7 @@ const AbsenceDetails = ({ isOpen, onClose, event }) => {
                 />
               </Box>
             )}
-            {event.notes && !isUserAbsentTeacher && (
+            {event.notes && (!isUserAbsentTeacher || isAdminMode) && (
               <Box position="relative">
                 <Text textStyle="h4" mb="9px">
                   Notes
@@ -217,17 +217,19 @@ const AbsenceDetails = ({ isOpen, onClose, event }) => {
               )}
 
             {/* Fill Absence Button*/}
-            {!event.substituteTeacher && !isUserAbsentTeacher && (
-              <Button
-                colorScheme="blue"
-                width="full"
-                height="44px"
-                fontSize="16px"
-                fontWeight="500"
-              >
-                Fill this Absence
-              </Button>
-            )}
+            {!event.substituteTeacher &&
+              !isUserAbsentTeacher &&
+              !isAdminMode && (
+                <Button
+                  colorScheme="blue"
+                  width="full"
+                  height="44px"
+                  fontSize="16px"
+                  fontWeight="500"
+                >
+                  Fill this Absence
+                </Button>
+              )}
           </VStack>
         </ModalBody>
       </ModalContent>

--- a/src/components/AbsenceStatusTag.tsx
+++ b/src/components/AbsenceStatusTag.tsx
@@ -5,14 +5,14 @@ import { FiCheckCircle, FiClock } from 'react-icons/fi';
 interface AbsenceStatusTagProps {
   isUserAbsentTeacher: boolean;
   isUserSubstituteTeacher: boolean;
-  isUserAdmin: boolean;
+  isAdminMode: boolean;
   substituteTeacherFullName?: string;
 }
 
 const AbsenceStatusTag = ({
   isUserAbsentTeacher,
   isUserSubstituteTeacher,
-  isUserAdmin,
+  isAdminMode,
   substituteTeacherFullName,
 }: AbsenceStatusTagProps) => {
   const theme = useTheme();
@@ -81,7 +81,7 @@ const AbsenceStatusTag = ({
           fontSize={theme.textStyles.label.fontSize}
           whiteSpace="nowrap"
           overflow="hidden"
-          maxWidth={isHovered ? 'none' : isUserAdmin ? '150px' : '210px'}
+          maxWidth={isHovered ? 'none' : isAdminMode ? '150px' : '210px'}
           sx={{
             maskImage:
               isOverflowing && !isHovered

--- a/src/components/InputForm.tsx
+++ b/src/components/InputForm.tsx
@@ -33,6 +33,7 @@ interface InputFormProps {
   userId: number;
   onTabChange: (tab: 'explore' | 'declared') => void;
   initialDate: Date;
+  isAdminMode: boolean;
 }
 
 const InputForm: React.FC<InputFormProps> = ({
@@ -41,13 +42,14 @@ const InputForm: React.FC<InputFormProps> = ({
   userId,
   onTabChange,
   initialDate,
+  isAdminMode,
 }) => {
   const toast = useToast();
   const { isOpen, onOpen, onClose: closeModal } = useDisclosure();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formData, setFormData] = useState({
     reasonOfAbsence: '',
-    absentTeacherId: '',
+    absentTeacherId: isAdminMode ? '' : String(userId),
     substituteTeacherId: '',
     locationId: '',
     subjectId: '',
@@ -220,56 +222,60 @@ const InputForm: React.FC<InputFormProps> = ({
       }}
     >
       <VStack sx={{ gap: '24px' }}>
-        <FormControl isRequired isInvalid={!!errors.absentTeacherId}>
-          <FormLabel sx={{ display: 'flex' }}>
-            <Text textStyle="h4">Teacher Absent</Text>
-          </FormLabel>
-          <SearchDropdown
-            label="Teacher"
-            type="user"
-            excludedId={formData.substituteTeacherId}
-            onChange={(value) => {
-              // Handle selected subject
-              setFormData((prev) => ({
-                ...prev,
-                absentTeacherId: value ? String(value.id) : '',
-              }));
-              // Clear error when user selects a value
-              if (errors.absentTeacherId) {
-                setErrors((prev) => ({
-                  ...prev,
-                  absentTeacherId: '',
-                }));
-              }
-            }}
-          />
-          <FormErrorMessage>{errors.absentTeacherId}</FormErrorMessage>
-        </FormControl>
+        {isAdminMode && (
+          <>
+            <FormControl isRequired isInvalid={!!errors.absentTeacherId}>
+              <FormLabel sx={{ display: 'flex' }}>
+                <Text textStyle="h4">Teacher Absent</Text>
+              </FormLabel>
+              <SearchDropdown
+                label="Teacher"
+                type="user"
+                excludedId={formData.substituteTeacherId}
+                onChange={(value) => {
+                  // Handle selected subject
+                  setFormData((prev) => ({
+                    ...prev,
+                    absentTeacherId: value ? String(value.id) : '',
+                  }));
+                  // Clear error when user selects a value
+                  if (errors.absentTeacherId) {
+                    setErrors((prev) => ({
+                      ...prev,
+                      absentTeacherId: '',
+                    }));
+                  }
+                }}
+              />
+              <FormErrorMessage>{errors.absentTeacherId}</FormErrorMessage>
+            </FormControl>
 
-        <FormControl>
-          <FormLabel sx={{ display: 'flex' }}>
-            <Text textStyle="h4">Substitute Teacher</Text>
-          </FormLabel>
-          <SearchDropdown
-            label="Teacher"
-            type="user"
-            excludedId={formData.absentTeacherId}
-            onChange={(value) => {
-              // Handle selected subject
-              setFormData((prev) => ({
-                ...prev,
-                substituteTeacherId: value ? String(value.id) : '',
-              }));
-              // Clear error when user selects a value
-              if (errors.substituteTeacherId) {
-                setErrors((prev) => ({
-                  ...prev,
-                  substituteTeacherId: '',
-                }));
-              }
-            }}
-          />
-        </FormControl>
+            <FormControl>
+              <FormLabel sx={{ display: 'flex' }}>
+                <Text textStyle="h4">Substitute Teacher</Text>
+              </FormLabel>
+              <SearchDropdown
+                label="Teacher"
+                type="user"
+                excludedId={formData.absentTeacherId}
+                onChange={(value) => {
+                  // Handle selected subject
+                  setFormData((prev) => ({
+                    ...prev,
+                    substituteTeacherId: value ? String(value.id) : '',
+                  }));
+                  // Clear error when user selects a value
+                  if (errors.substituteTeacherId) {
+                    setErrors((prev) => ({
+                      ...prev,
+                      substituteTeacherId: '',
+                    }));
+                  }
+                }}
+              />
+            </FormControl>
+          </>
+        )}
 
         <FormControl isRequired isInvalid={!!errors.subjectId}>
           <FormLabel sx={{ display: 'flex' }}>

--- a/src/components/LessonPlanView.tsx
+++ b/src/components/LessonPlanView.tsx
@@ -15,6 +15,7 @@ const LessonPlanDisplay = ({
   fileName,
   fileSize,
   isUserAbsentTeacher,
+  isAdminMode,
 }) => {
   const theme = useTheme();
 
@@ -47,7 +48,7 @@ const LessonPlanDisplay = ({
         </Flex>
       </Link>
 
-      {isUserAbsentTeacher && (
+      {isUserAbsentTeacher && !isAdminMode && (
         <IconButton
           aria-label="Swap Lesson Plan"
           icon={
@@ -118,6 +119,7 @@ const LessonPlanView = ({
   absentTeacherFirstName,
   isUserAbsentTeacher,
   isUserSubstituteTeacher,
+  isAdminMode,
 }) => {
   const getFileName = (url) => (url ? 'File name' : '');
   const getFileSize = (url) => (url ? 'File size' : '');
@@ -128,8 +130,9 @@ const LessonPlanView = ({
       fileName={getFileName(lessonPlan)}
       fileSize={getFileSize(lessonPlan)}
       isUserAbsentTeacher={isUserAbsentTeacher}
+      isAdminMode={isAdminMode}
     />
-  ) : isUserAbsentTeacher ? (
+  ) : isUserAbsentTeacher && !isAdminMode ? (
     <NoLessonPlanDeclaredDisplay />
   ) : (
     <NoLessonPlanViewingDisplay

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -436,6 +436,7 @@ const Calendar: React.FC = () => {
         isOpen={isAbsenceDetailsOpen}
         onClose={onAbsenceDetailsClose}
         event={selectedEvent}
+        isAdminMode={isAdminMode}
       />
 
       <Modal isOpen={isInputFormOpen} onClose={onInputFormClose} isCentered>

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -457,6 +457,7 @@ const Calendar: React.FC = () => {
               initialDate={selectedDate!!}
               userId={userData.id}
               onTabChange={setActiveTab}
+              isAdminMode={isAdminMode}
             />
           </ModalBody>
         </ModalContent>


### PR DESCRIPTION
## Notion Ticket

[Frontend: Segment Admin vs Teacher ](https://www.notion.so/uwblueprintexecs/Frontend-Segment-Admin-vs-Teacher-19a10f3fb1dc80b7814ff2360ff7c52e)

## Summary & Review Focus
- Segmented teachers from admins based on isAdminMode (rather than isAdmin)
- Removed "Fill this Absence" button from AdminMode
  - Admin must be in TeacherMode to fill via the button
- Removed swapLessonPlan button, editNotes button, uploadLessonPlan component from AdminMode
  - Admin must be in TeacherMode to be treated as the absentTeacher
- Removed VisibilityTag from AdminMode
  - Only appears for absentTeacher and substituteTeacher
- Created teacher version of InputForm
  - No teacher dropdowns
  - userId automatically becomes absentTeacherId
![image](https://github.com/user-attachments/assets/cfbcca99-f9f9-48ce-92c6-aaa4df8c96bf)

<!-- Briefly describe the implementation, key changes, and areas needing review -->

## Testing Instructions
0. Log in with the Sistema Blueprint account (is an admin)

Test teacher view
1. Toggle to teacher view
2. Declare an absence
  a. Ensure InputForm to declare absence has no teacher dropdowns
  b. Ensure switch to "My Declared and Filled Absences" tab on submission
5. Click on declared absence
  a. Ensure references to absentTeacher are "Sistema"

Test admin view
1. Toggle to admin view
2. Click on an absence in the "Explore Fillable Absences" tab
  a. Ensure there is no "Fill this Absence" button
3. Click on the previously teacher-view-declared absence (with Sistema as the absentTeacher)
  a. Ensure there is no swapLessonPlan button, editNotes button, uploadLessonPlan component
4. Click on an absence with a substitute teacher
  a. Ensure there is no VisibilityTag

## Checklist

- [x] PR title is descriptive and in imperative tense
- [x] Commit messages are descriptive, atomic, and follow best practices
- [x] Linter(s) have been run
- [x] Requested reviews from the PL and relevant team members
