### PR TITLE
Absence Adjustment

### DIFF
--- a/src/components/AbsenceDetails.tsx
+++ b/src/components/AbsenceDetails.tsx
@@ -1,52 +1,128 @@
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Box,
-  Button,
-  Flex,
-  IconButton,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
   Text,
   VStack,
+  Flex,
+  IconButton,
+  Button,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverArrow,
+  PopoverCloseButton,
+  PopoverHeader,
+  PopoverBody,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  useDisclosure,
   useTheme,
   useToast,
+  Portal,
 } from '@chakra-ui/react';
-import { useUserData } from '@hooks/useUserData';
-import { Buildings, Calendar } from 'iconsax-react';
-import { useRouter } from 'next/router';
-import React, { useState } from 'react';
-import { FiEdit2, FiMapPin, FiTrash2, FiUser } from 'react-icons/fi';
+import { FiEdit2, FiMapPin, FiTrash2, FiUser, FiX } from 'react-icons/fi';
 import { IoEyeOutline } from 'react-icons/io5';
+import { Buildings, Calendar } from 'iconsax-react';
+import { useUserData } from '@hooks/useUserData';
+import { useRouter } from 'next/router';
+
 import AbsenceStatusTag from './AbsenceStatusTag';
 import LessonPlanView from './LessonPlanView';
 import { Role } from '@utils/types';
 
-const AbsenceDetails = ({ isOpen, onClose, event, isAdminMode, onDelete }) => {
+const AbsenceDetails = (props) => {
+  const { isAdminMode, onDelete } = props;
+
+  const event = props.event || (props.eventInfo ? props.eventInfo.event : null);
+  const externalIsOpen = props.isOpen;
+  const externalOnClose = props.onClose;
+
   const theme = useTheme();
-  const userData = useUserData();
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const cancelRef = React.useRef();
   const toast = useToast();
   const router = useRouter();
+  const userData = useUserData();
+  const eventRef = useRef<HTMLElement | null>(null);
+
+  const [internalIsOpen, setInternalIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (externalIsOpen !== undefined) {
+      setInternalIsOpen(externalIsOpen);
+    }
+  }, [externalIsOpen]);
+
+  const handleClose = () => {
+    setInternalIsOpen(false);
+    if (externalOnClose) {
+      externalOnClose();
+    }
+  };
+
+  const {
+    isOpen: isDeleteDialogOpen,
+    onOpen: onDeleteDialogOpen,
+    onClose: onDeleteDialogClose,
+  } = useDisclosure();
+
+  const [isDeleting, setIsDeleting] = useState(false);
 
   if (!event) return null;
 
-  const userId = userData.id;
-  const isUserAbsentTeacher = userId === event.absentTeacher.id;
-  const isUserSubstituteTeacher = userId === event.substituteTeacher?.id;
-  const isUserAdmin = userData.role === Role.ADMIN;
+  const title = event.title || 'Untitled Event';
+
+  const location =
+    event.location ||
+    (event.extendedProps ? event.extendedProps.location : '') ||
+    '';
+  const startDate = event.start;
+  const absentTeacher =
+    event.absentTeacher ||
+    (event.extendedProps ? event.extendedProps.absentTeacher : null) ||
+    null;
+  const absentTeacherFullName =
+    event.absentTeacherFullName ||
+    (event.extendedProps ? event.extendedProps.absentTeacherFullName : '') ||
+    '';
+  const substituteTeacher =
+    event.substituteTeacher ||
+    (event.extendedProps ? event.extendedProps.substituteTeacher : null) ||
+    null;
+  const substituteTeacherFullName =
+    event.substituteTeacherFullName ||
+    (event.extendedProps
+      ? event.extendedProps.substituteTeacherFullName
+      : '') ||
+    '';
+  const lessonPlan =
+    event.lessonPlan ||
+    (event.extendedProps ? event.extendedProps.lessonPlan : '') ||
+    '';
+  const reasonOfAbsence =
+    event.reasonOfAbsence ||
+    (event.extendedProps ? event.extendedProps.reasonOfAbsence : '') ||
+    '';
+  const notes =
+    event.notes || (event.extendedProps ? event.extendedProps.notes : '') || '';
+  const roomNumber =
+    event.roomNumber ||
+    (event.extendedProps ? event.extendedProps.roomNumber : '') ||
+    '';
+  const absenceId =
+    event.absenceId ||
+    (event.extendedProps ? event.extendedProps.absenceId : null);
+
+  const userId = userData?.id;
+  const isUserAbsentTeacher = userId === absentTeacher?.id;
+  const isUserSubstituteTeacher = userId === substituteTeacher?.id;
+  const isUserAdmin = userData?.role === Role.ADMIN;
 
   const handleDeleteClick = () => {
-    setIsDeleteDialogOpen(true);
-  };
-
-  const handleDeleteCancel = () => {
-    setIsDeleteDialogOpen(false);
+    onDeleteDialogOpen();
   };
 
   const handleDeleteConfirm = async () => {
@@ -54,12 +130,10 @@ const AbsenceDetails = ({ isOpen, onClose, event, isAdminMode, onDelete }) => {
       setIsDeleting(true);
       const response = await fetch(`/api/deleteAbsence`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           isUserAdmin: isUserAdmin,
-          absenceId: event.absenceId,
+          absenceId: absenceId,
         }),
       });
 
@@ -75,11 +149,11 @@ const AbsenceDetails = ({ isOpen, onClose, event, isAdminMode, onDelete }) => {
         isClosable: true,
       });
 
-      setIsDeleteDialogOpen(false);
-      onClose();
+      onDeleteDialogClose();
+      handleClose();
 
       if (onDelete) {
-        onDelete(event.absenceId);
+        onDelete(absenceId);
       } else {
         router.reload();
       }
@@ -95,240 +169,428 @@ const AbsenceDetails = ({ isOpen, onClose, event, isAdminMode, onDelete }) => {
       setIsDeleting(false);
     }
   };
+
+  const dayOfWeek = startDate ? new Date(startDate).getDay() : 0;
+
+  const placement = dayOfWeek <= 3 ? 'right' : 'left';
+
+  const getCalendarGridInfo = () => {
+    const calendarEl = document.querySelector('.fc-daygrid-body');
+    if (!calendarEl) return null;
+
+    const calendarRect = calendarEl.getBoundingClientRect();
+
+    const dayCells = document.querySelectorAll('.fc-daygrid-day');
+    if (!dayCells.length) return null;
+
+    const cellWidth = calendarRect.width / 7;
+
+    return {
+      cellWidth,
+      calendarLeft: calendarRect.left,
+      calendarRight: calendarRect.right,
+      calendarTop: calendarRect.top,
+      calendarBottom: calendarRect.bottom,
+    };
+  };
+
+  const calculatePopoverPosition = () => {
+    if (!event.clickPosition) return null;
+
+    const gridInfo = getCalendarGridInfo();
+    if (!gridInfo) return null;
+
+    const { x, y } = event.clickPosition;
+    const { cellWidth, calendarLeft, calendarRight } = gridInfo;
+
+    const relativeX = x - calendarLeft;
+
+    const clickedColumn = Math.floor(relativeX / cellWidth);
+
+    const columnCenterX =
+      calendarLeft + clickedColumn * cellWidth + cellWidth / 2;
+
+    const offsetX =
+      dayOfWeek <= 3
+        ? columnCenterX + cellWidth * 0.5
+        : columnCenterX - cellWidth * 0.5;
+
+    const finalX = Math.max(
+      calendarLeft + 10,
+      Math.min(offsetX, calendarRight - 10)
+    );
+
+    return {
+      x: finalX,
+      y,
+    };
+  };
+
+  const PopoverContents = () => (
+    <VStack spacing="18px" align="stretch">
+      <Text fontSize="lg" fontWeight="semibold">
+        {title}
+      </Text>
+
+      <Flex gap="13px">
+        <FiMapPin size="20px" color={theme.colors.primaryBlue[300]} />
+        <Text fontSize="sm">{location}</Text>
+      </Flex>
+
+      <Flex gap="13px" mt="-8px">
+        <Calendar size="20px" color={theme.colors.primaryBlue[300]} />
+        <Text fontSize="sm">
+          {startDate
+            ? new Date(startDate).toLocaleDateString('en-CA', {
+                weekday: 'long',
+                month: 'long',
+                day: 'numeric',
+              })
+            : 'N/A'}
+        </Text>
+      </Flex>
+
+      <Flex gap="13px" mt="-8px">
+        <FiUser size="20px" color={theme.colors.primaryBlue[300]} />
+        <Text fontSize="sm">{absentTeacherFullName}</Text>
+      </Flex>
+
+      {roomNumber && (
+        <Flex gap="13px" mt="-8px">
+          <Buildings size="20px" color={theme.colors.primaryBlue[300]} />
+          <Text fontSize="sm">Room {roomNumber}</Text>
+        </Flex>
+      )}
+
+      <Box>
+        <Text fontWeight="semibold" mb="9px">
+          Lesson Plan
+        </Text>
+        <LessonPlanView
+          lessonPlan={lessonPlan}
+          absentTeacherFirstName={absentTeacher?.firstName}
+          isUserAbsentTeacher={isUserAbsentTeacher}
+          isUserSubstituteTeacher={isUserSubstituteTeacher}
+          isAdminMode={isAdminMode}
+        />
+      </Box>
+
+      {(isAdminMode || isUserAbsentTeacher) && (
+        <Box>
+          <Text fontWeight="semibold" mb="9px">
+            Reason of Absence
+          </Text>
+          <Box
+            fontSize="12px"
+            bg={theme.colors.neutralGray[50]}
+            p="15px"
+            borderRadius="10px"
+          >
+            {reasonOfAbsence}
+          </Box>
+        </Box>
+      )}
+
+      {isUserAbsentTeacher && !isAdminMode && (
+        <Box position="relative">
+          <Text fontWeight="semibold" mb="9px">
+            Notes
+          </Text>
+          <Box
+            fontSize="12px"
+            bg={theme.colors.neutralGray[50]}
+            p="15px"
+            borderRadius="10px"
+          >
+            {notes}
+          </Box>
+          <IconButton
+            aria-label="Edit Notes"
+            icon={<FiEdit2 size="15px" color={theme.colors.neutralGray[600]} />}
+            size="sm"
+            variant="ghost"
+            position="absolute"
+            bottom="8px"
+            right="16px"
+          />
+        </Box>
+      )}
+
+      {notes && (!isUserAbsentTeacher || isAdminMode) && (
+        <Box>
+          <Text fontWeight="semibold" mb="9px">
+            Notes
+          </Text>
+          <Box
+            fontSize="12px"
+            bg={theme.colors.neutralGray[50]}
+            p="15px"
+            borderRadius="10px"
+          >
+            {notes}
+          </Box>
+        </Box>
+      )}
+
+      {substituteTeacher &&
+        !isAdminMode &&
+        (isUserAbsentTeacher || isUserSubstituteTeacher) && (
+          <Flex gap="10px" align="center" fontSize="xs">
+            <IoEyeOutline size="14px" />
+            {isUserAbsentTeacher ? (
+              <Text>
+                Only visible to <strong>{absentTeacher?.firstName}</strong> and{' '}
+                <strong>{substituteTeacher?.firstName}</strong>.
+              </Text>
+            ) : (
+              <Text>
+                Only visible to <strong>{substituteTeacher?.firstName}</strong>{' '}
+                and <strong>{absentTeacher?.firstName}</strong>.
+              </Text>
+            )}
+          </Flex>
+        )}
+
+      {!substituteTeacher && !isUserAbsentTeacher && !isAdminMode && (
+        <Button width="full" height="44px" fontSize="16px" fontWeight="500">
+          Fill this Absence
+        </Button>
+      )}
+    </VStack>
+  );
+
+  const PopoverWrapper = ({ children }) => (
+    <PopoverContent
+      width="362px"
+      borderRadius="15px"
+      boxShadow="0px 0px 25px rgba(0,0,0,0.25)"
+      _focus={{ outline: 'none' }}
+    >
+      <PopoverArrow />
+      <PopoverCloseButton />
+      <PopoverHeader borderBottom="none" pt="16px" pb="0">
+        <Flex justify="space-between" align="center" position="relative">
+          <AbsenceStatusTag
+            isUserAbsentTeacher={isUserAbsentTeacher}
+            isUserSubstituteTeacher={isUserSubstituteTeacher}
+            isAdminMode={isAdminMode}
+            substituteTeacherFullName={substituteTeacherFullName}
+          />
+          <Flex position="absolute" right="0">
+            {isAdminMode && (
+              <IconButton
+                aria-label="Edit Absence"
+                icon={<FiEdit2 size="15px" color={theme.colors.text.body} />}
+                size="sm"
+                variant="ghost"
+              />
+            )}
+
+            {(isAdminMode || (isUserAbsentTeacher && !substituteTeacher)) && (
+              <IconButton
+                aria-label="Delete Absence"
+                icon={<FiTrash2 size="15px" color={theme.colors.text.body} />}
+                size="sm"
+                variant="ghost"
+                onClick={handleDeleteClick}
+              />
+            )}
+          </Flex>
+        </Flex>
+      </PopoverHeader>
+
+      <PopoverBody pt="10px">{children}</PopoverBody>
+    </PopoverContent>
+  );
+
+  const getEventBounds = () => {
+    if (eventRef.current) {
+      const bounds = eventRef.current.getBoundingClientRect();
+      return {
+        top: bounds.top,
+        left: bounds.left,
+        width: bounds.width,
+        height: bounds.height,
+      };
+    }
+    return null;
+  };
+
   return (
     <>
-      <Modal isOpen={isOpen} onClose={onClose} size="lg" isCentered>
-        <ModalContent
-          width="362px"
-          borderRadius="15px"
-          padding="30px"
-          boxShadow="0px 0px 25px 0px rgba(0, 0, 0, 0.25)"
+      {props.eventInfo ? (
+        <Popover
+          isOpen={internalIsOpen}
+          onClose={handleClose}
+          placement={placement}
+          closeOnBlur={true}
+          gutter={10}
+          strategy="fixed"
+          returnFocusOnClose={false}
         >
-          <ModalHeader p="0">
-            <Flex justify="space-between" align="center" position="relative">
-              <AbsenceStatusTag
-                isUserAbsentTeacher={isUserAbsentTeacher}
-                isUserSubstituteTeacher={isUserSubstituteTeacher}
-                isAdminMode={isAdminMode}
-                substituteTeacherFullName={event.substituteTeacherFullName}
-              />
-              <Flex position="absolute" right="0">
-                {isAdminMode && (
-                  <IconButton
-                    aria-label="Edit Absence"
-                    icon={
-                      <FiEdit2
-                        size="15px"
-                        color={theme.colors.neutralGray[600]}
-                      />
-                    }
-                    size="sm"
-                    variant="ghost"
-                  />
-                )}
+          <PopoverTrigger>
+            <Box
+              onClick={() => setInternalIsOpen(true)}
+              cursor="pointer"
+              className="fc-event-main"
+            >
+              <Box className="fc-event-title">{title}</Box>
+              <Box fontSize="sm">{location}</Box>
+            </Box>
+          </PopoverTrigger>
 
-                {(isAdminMode ||
-                  (isUserAbsentTeacher && !event.substituteTeacher)) && (
-                  <IconButton
-                    aria-label="Delete Absence"
-                    icon={
-                      <FiTrash2
-                        size="15px"
-                        color={theme.colors.neutralGray[600]}
-                      />
-                    }
-                    size="sm"
-                    variant="ghost"
-                    onClick={handleDeleteClick}
-                  />
-                )}
-                <ModalCloseButton
-                  color={theme.colors.text.body}
-                  position="static"
-                />
-              </Flex>
-            </Flex>
-          </ModalHeader>
+          <PopoverWrapper>
+            <PopoverContents />
+          </PopoverWrapper>
+        </Popover>
+      ) : (
+        internalIsOpen && (
+          <Portal>
+            {event.clickPosition ? (
+              (() => {
+                const position = calculatePopoverPosition();
 
-          <ModalBody sx={{ padding: '20px 0 0 0' }}>
-            <VStack spacing="18px" align="stretch">
-              <Text textStyle="h2">{event.title}</Text>
-              <Flex gap="13px">
-                <FiMapPin size="20px" color={theme.colors.primaryBlue[300]} />
-                <Text textStyle="subtitle" color={theme.colors.text.body}>
-                  {event.location}
-                </Text>
-              </Flex>
-              <Flex gap="13px" mt="-8px">
-                <Calendar size="20px" color={theme.colors.primaryBlue[300]} />
-                <Text textStyle="subtitle" color={theme.colors.text.body}>
-                  {event.start
-                    ? new Date(event.start).toLocaleDateString('en-CA', {
-                        weekday: 'long',
-                        month: 'long',
-                        day: 'numeric',
-                      })
-                    : 'N/A'}
-                </Text>
-              </Flex>
-              <Flex gap="13px" mt="-8px">
-                <FiUser size="20px" color={theme.colors.primaryBlue[300]} />
-                <Text textStyle="subtitle" color={theme.colors.text.body}>
-                  {event.absentTeacherFullName}
-                </Text>
-              </Flex>
-              {event.roomNumber && (
-                <Flex gap="13px" mt="-8px">
-                  <Buildings
-                    size="20px"
-                    color={theme.colors.primaryBlue[300]}
-                  />
-                  <Text textStyle="subtitle" color={theme.colors.text.body}>
-                    Room {event.roomNumber}
-                  </Text>
-                </Flex>
-              )}
-              <Box>
-                <Text textStyle="h4" mb="9px">
-                  Lesson Plan
-                </Text>
-                <LessonPlanView
-                  lessonPlan={event.lessonPlan}
-                  absentTeacherFirstName={event.absentTeacher.firstName}
-                  isUserAbsentTeacher={isUserAbsentTeacher}
-                  isUserSubstituteTeacher={isUserSubstituteTeacher}
-                  isAdminMode={isAdminMode}
-                />
-              </Box>
-              {(isAdminMode || isUserAbsentTeacher) && (
-                <Box>
-                  <Text textStyle="h4" mb="9px">
-                    Reason of Absence
-                  </Text>
-                  <Box
-                    fontSize="12px"
-                    sx={{
-                      padding: '15px 15px 33px 15px',
-                      borderRadius: '10px',
-                    }}
-                    background={theme.colors.neutralGray[50]}
+                if (!position) {
+                  return (
+                    <Popover
+                      isOpen={true}
+                      onClose={handleClose}
+                      placement={placement}
+                      closeOnBlur={true}
+                      gutter={10}
+                      strategy="fixed"
+                      returnFocusOnClose={false}
+                    >
+                      <PopoverTrigger>
+                        <Box
+                          position="fixed"
+                          top={`${event.clickPosition.y}px`}
+                          left={`${event.clickPosition.x}px`}
+                          width="1px"
+                          height="1px"
+                          opacity={0}
+                          pointerEvents="none"
+                          zIndex={-1}
+                        />
+                      </PopoverTrigger>
+
+                      <PopoverWrapper>
+                        <PopoverContents />
+                      </PopoverWrapper>
+                    </Popover>
+                  );
+                }
+
+                return (
+                  <Popover
+                    isOpen={true}
+                    onClose={handleClose}
+                    placement={placement}
+                    closeOnBlur={true}
+                    gutter={10}
+                    strategy="fixed"
+                    returnFocusOnClose={false}
                   >
-                    {event.reasonOfAbsence}
-                  </Box>
-                </Box>
-              )}
-              {isUserAbsentTeacher && !isAdminMode && (
-                <Box position="relative">
-                  <Text textStyle="h4" mb="9px">
-                    Notes
-                  </Text>
-                  <Box
-                    fontSize="12px"
-                    sx={{
-                      padding: '15px 15px 33px 15px',
-                      borderRadius: '10px',
-                    }}
-                    background={theme.colors.neutralGray[50]}
-                  >
-                    {event.notes}
-                  </Box>
-
-                  <IconButton
-                    aria-label="Edit Notes"
-                    icon={
-                      <FiEdit2
-                        size="15px"
-                        color={theme.colors.neutralGray[600]}
+                    <PopoverTrigger>
+                      <Box
+                        position="fixed"
+                        top={`${position.y}px`}
+                        left={`${position.x}px`}
+                        width="1px"
+                        height="1px"
+                        opacity={0}
+                        pointerEvents="none"
+                        zIndex={-1}
                       />
-                    }
+                    </PopoverTrigger>
+
+                    <PopoverWrapper>
+                      <PopoverContents />
+                    </PopoverWrapper>
+                  </Popover>
+                );
+              })()
+            ) : (
+              <Box
+                position="fixed"
+                right="20px"
+                top="20%"
+                zIndex={1500}
+                width="362px"
+              >
+                <Box
+                  borderRadius="15px"
+                  boxShadow="0px 0px 25px rgba(0,0,0,0.25)"
+                  bg="white"
+                  position="relative"
+                >
+                  <IconButton
+                    aria-label="Close"
+                    icon={<FiX />}
                     size="sm"
-                    variant="ghost"
                     position="absolute"
-                    bottom="8px"
-                    right="16px"
+                    top="8px"
+                    right="8px"
+                    onClick={handleClose}
                   />
-                </Box>
-              )}
-              {event.notes && (!isUserAbsentTeacher || isAdminMode) && (
-                <Box position="relative">
-                  <Text textStyle="h4" mb="9px">
-                    Notes
-                  </Text>
+                  <Box p="16px 16px 0">
+                    <Flex
+                      justify="space-between"
+                      align="center"
+                      position="relative"
+                    >
+                      <AbsenceStatusTag
+                        isUserAbsentTeacher={isUserAbsentTeacher}
+                        isUserSubstituteTeacher={isUserSubstituteTeacher}
+                        isAdminMode={isAdminMode}
+                        substituteTeacherFullName={substituteTeacherFullName}
+                      />
+                      <Flex position="absolute" right="0">
+                        {isAdminMode && (
+                          <IconButton
+                            aria-label="Edit Absence"
+                            icon={
+                              <FiEdit2
+                                size="15px"
+                                color={theme.colors.text.body}
+                              />
+                            }
+                            size="sm"
+                            variant="ghost"
+                          />
+                        )}
 
-                  <Box
-                    fontSize="12px"
-                    sx={{
-                      padding: '15px 15px 33px 15px',
-                      borderRadius: '10px',
-                      background: `${theme.colors.neutralGray[50]}`,
-                    }}
-                  >
-                    {event.notes}
+                        {(isAdminMode ||
+                          (isUserAbsentTeacher && !substituteTeacher)) && (
+                          <IconButton
+                            aria-label="Delete Absence"
+                            icon={
+                              <FiTrash2
+                                size="15px"
+                                color={theme.colors.text.body}
+                              />
+                            }
+                            size="sm"
+                            variant="ghost"
+                            onClick={handleDeleteClick}
+                          />
+                        )}
+                      </Flex>
+                    </Flex>
+                  </Box>
+                  <Box pt="10px" px="16px" pb="16px">
+                    <PopoverContents />
                   </Box>
                 </Box>
-              )}
+              </Box>
+            )}
+          </Portal>
+        )
+      )}
 
-              {/* Visibility Tag*/}
-              {event.substituteTeacher &&
-                !isAdminMode &&
-                (isUserAbsentTeacher || isUserSubstituteTeacher) && (
-                  <Flex gap="10px" align="center" textStyle="caption">
-                    {isUserAbsentTeacher ? (
-                      <>
-                        <IoEyeOutline size="14px" />
-                        <Text>
-                          {' '}
-                          Only visible to{' '}
-                          <Text as="span" fontWeight={700}>
-                            {event.absentTeacher.firstName}
-                          </Text>{' '}
-                          and{' '}
-                          <Text as="span" fontWeight={700}>
-                            {event.substituteTeacher.firstName}
-                          </Text>
-                          .
-                        </Text>
-                      </>
-                    ) : isUserSubstituteTeacher ? (
-                      <>
-                        <IoEyeOutline size="14px" />
-                        <Text>
-                          {' '}
-                          Only visible to{' '}
-                          <Text as="span" fontWeight={700}>
-                            {event.substituteTeacher.firstName}
-                          </Text>{' '}
-                          and{' '}
-                          <Text as="span" fontWeight={700}>
-                            {event.absentTeacher.firstName}
-                          </Text>
-                          .
-                        </Text>
-                      </>
-                    ) : null}
-                  </Flex>
-                )}
-
-              {/* Fill Absence Button*/}
-              {!event.substituteTeacher &&
-                !isUserAbsentTeacher &&
-                !isAdminMode && (
-                  <Button
-                    width="full"
-                    height="44px"
-                    fontSize="16px"
-                    fontWeight="500"
-                  >
-                    Fill this Absence
-                  </Button>
-                )}
-            </VStack>
-          </ModalBody>
-        </ModalContent>
-      </Modal>
       <Modal
         isOpen={isDeleteDialogOpen}
-        onClose={handleDeleteCancel}
+        onClose={onDeleteDialogClose}
         isCentered
       >
         <ModalOverlay />
@@ -339,7 +601,7 @@ const AbsenceDetails = ({ isOpen, onClose, event, isAdminMode, onDelete }) => {
             <Text>Are you sure you want to delete this absence?</Text>
           </ModalBody>
           <ModalFooter>
-            <Button onClick={handleDeleteCancel} mr={3}>
+            <Button onClick={onDeleteDialogClose} mr={3}>
               Cancel
             </Button>
             <Button onClick={handleDeleteConfirm} isLoading={isDeleting}>

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -170,6 +170,12 @@ const Calendar: React.FC = () => {
   }, [updateMonthYearTitle]);
 
   const handleAbsenceClick = (clickInfo: EventClickArg) => {
+    // Get the click position from the event
+    const clickPosition = {
+      x: clickInfo.jsEvent.clientX,
+      y: clickInfo.jsEvent.clientY,
+    };
+
     setSelectedEvent({
       title: clickInfo.event.title || 'Untitled Event',
       start: clickInfo.event.start,
@@ -187,6 +193,8 @@ const Calendar: React.FC = () => {
       reasonOfAbsence: clickInfo.event.extendedProps.reasonOfAbsence || '',
       notes: clickInfo.event.extendedProps.notes || '',
       absenceId: clickInfo.event.extendedProps.absenceId,
+      // Add click position to the selected event data
+      clickPosition: clickPosition,
     });
     onAbsenceDetailsOpen();
   };

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -25,6 +25,7 @@ export interface EventDetails {
   reasonOfAbsence: string;
   notes: string;
   absenceId: number;
+  clickPosition?: { x: number; y: number };
 }
 
 export interface AbsenceAPI {


### PR DESCRIPTION
# Notion Ticket

Display AbsenceDetails Beside the Clicked Absence (https://www.notion.so/uwblueprintexecs/Display-AbsenceDetails-Beside-the-Clicked-Absence-1be10f3fb1dc809d8e4acf8d22fcc26c?pvs=4)

## Summary & Review Focus

<!-- Briefly describe the implementation, key changes, and areas needing review -->
Fixed the way how the Absence Details look on the Calendar...it now is offsetted to the left/right of the event.
Also added a little arrow popover so users can see which calendar event it's in regards. 

## Testing Instructions

1. Click Events and see the popup on side instead of on top -- spacing is exact and nothing exists the screen.
2. Check Admin & Teacher Panel for both.

## Checklist

- [ ] PR title is descriptive and in imperative tense
- [ ] Commit messages are descriptive, atomic, and follow best practices
- [ ] Linter(s) have been run
- [ ] Requested reviews from the PL and relevant team members
