### PR TITLE
address nit: space between 'dashboard' text & icon on screens with smaller widths

### DIFF
--- a/src/components/CalendarHeader.tsx
+++ b/src/components/CalendarHeader.tsx
@@ -61,6 +61,7 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({
       marginBottom={theme.space[4]}
       alignItems="center"
       width="100%"
+      gap={theme.space[1.5]}
     >
       <HStack spacing={theme.space[6]}>
         <HStack spacing={1}>

--- a/src/components/CalendarHeader.tsx
+++ b/src/components/CalendarHeader.tsx
@@ -61,7 +61,7 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({
       marginBottom={theme.space[4]}
       alignItems="center"
       width="100%"
-      gap={theme.space[1.5]}
+      gap={theme.space[2]}
     >
       <HStack spacing={theme.space[6]}>
         <HStack spacing={1}>

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -56,7 +56,7 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
       borderColor="neutralGray.300"
       px={theme.space[16]}
       py={theme.space[4]}
-      gap={theme.space[1.5]}
+      gap={theme.space[2]}
     >
       <HStack spacing={theme.space[8]}>
         <IconButton

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -56,6 +56,7 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
       borderColor="neutralGray.300"
       px={theme.space[16]}
       py={theme.space[4]}
+      gap={theme.space[1.5]}
     >
       <HStack spacing={theme.space[8]}>
         <IconButton


### PR DESCRIPTION
# Notion Ticket

[NITS](https://www.notion.so/uwblueprintexecs/NITS-1c110f3fb1dc8006beccfb7b405730e2?pvs=4)

## Summary & Review Focus

In both scenarios, since we had only 2 elements in the flex box used the `gap` property and theme's spacing.

- [ ] Do I need to decrease/increase the spacing for either scenario?

## Testing Instructions

1. <!-- List steps to verify the changes -->

## Checklist

- [ ] PR title is descriptive and in imperative tense
- [ ] Commit messages are descriptive, atomic, and follow best practices
- [ ] Linter(s) have been run
- [ ] Requested reviews from the PL and relevant team members
