### PR TITLE
address nits: fit table row one line with no ellipsis

### DIFF
--- a/src/components/UserManagementTable.tsx
+++ b/src/components/UserManagementTable.tsx
@@ -4,6 +4,7 @@ import {
   Avatar,
   Box,
   Divider,
+  Flex,
   HStack,
   Icon,
   Input,
@@ -18,8 +19,6 @@ import {
   Th,
   Thead,
   Tr,
-  Wrap,
-  WrapItem,
 } from '@chakra-ui/react';
 
 import { getAbsenceColor } from '@utils/getAbsenceColor';
@@ -238,7 +237,7 @@ export const UserManagementTable: React.FC<UserManagementTableProps> = ({
               <SortableHeader field="email" label="Email" icon={FiMail} />
               <SortableHeader
                 field="absences"
-                label="Abs."
+                label="Absent"
                 icon={FiClock}
                 centered
               />
@@ -250,6 +249,7 @@ export const UserManagementTable: React.FC<UserManagementTableProps> = ({
                     textStyle="h4"
                     color="text.subtitle"
                     textTransform="none"
+                    whiteSpace="nowrap"
                   >
                     Email Subscriptions
                   </Text>
@@ -301,30 +301,29 @@ export const UserManagementTable: React.FC<UserManagementTableProps> = ({
                       />
                     </Td>
                     <Td py="6px">
-                      <Wrap spacing={2}>
+                      <Flex gap={2} wrap="nowrap">
                         {user.mailingLists?.map((mailingList, index) => (
-                          <WrapItem key={index}>
-                            <Tag
-                              height="28px"
-                              variant="subtle"
-                              bg={mailingList.subject.colorGroup.colorCodes[3]}
-                            >
-                              <TagLabel>
-                                <Text
-                                  color={
-                                    mailingList.subject.colorGroup.colorCodes[0]
-                                  }
-                                  textStyle="label"
-                                  whiteSpace="nowrap"
-                                  overflow="hidden"
-                                >
-                                  {mailingList.subject.name}
-                                </Text>
-                              </TagLabel>
-                            </Tag>
-                          </WrapItem>
+                          <Tag
+                            height="28px"
+                            variant="subtle"
+                            bg={mailingList.subject.colorGroup.colorCodes[3]}
+                            key={index}
+                          >
+                            <TagLabel>
+                              <Text
+                                color={
+                                  mailingList.subject.colorGroup.colorCodes[0]
+                                }
+                                textStyle="label"
+                                whiteSpace="nowrap"
+                                overflow="hidden"
+                              >
+                                {mailingList.subject.name}
+                              </Text>
+                            </TagLabel>
+                          </Tag>
                         ))}
-                      </Wrap>
+                      </Flex>
                     </Td>
                   </Tr>
                 ))


### PR DESCRIPTION
# Notion Ticket

[NITS](https://www.notion.so/uwblueprintexecs/NITS-1c110f3fb1dc8006beccfb7b405730e2?pvs=4)
Addresses:
> Make the headers and each row of the user management table fit on one line with no ellipsis (just scroll left and right)
## Summary & Review Focus

**Implementation detail**
- ellipsis was hardcoded unintentionally as `Abs.` Simply wrote out `Absent`
- For displaying the text `Email Subscriptions` in online used `whiteSpace` instead of `textWrap` because typescript was yelling at me. Am basically setting [text-wrap-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap-mode)
- For displaying the email subscription tags in one-line, swapped out `Wrap` & `WrapItem` with a Flex box with nowrap 

## Testing Instructions

1. <!-- List steps to verify the changes -->

## Checklist

- [ ] PR title is descriptive and in imperative tense
- [ ] Commit messages are descriptive, atomic, and follow best practices
- [ ] Linter(s) have been run
- [ ] Requested reviews from the PL and relevant team members
