### PR TITLE
nits: admin dashboard scrollbars

### DIFF
--- a/src/components/TotalAbsencesCard.tsx
+++ b/src/components/TotalAbsencesCard.tsx
@@ -65,7 +65,12 @@ export default function TotalAbsencesCard({
         </Heading>
       </CardHeader>
       <Divider />
-      <CardBody display="flex" flexDirection="column" overflowY="auto">
+      <CardBody
+        display="flex"
+        flexDirection="column"
+        overflowX="auto"
+        overflowY="hidden"
+      >
         <HStack align="flex-start" justify="space-between" width="100%">
           <HStack align="flex-start" gap="28px">
             <CircularProgress

--- a/src/components/TotalAbsencesCard.tsx
+++ b/src/components/TotalAbsencesCard.tsx
@@ -100,7 +100,7 @@ export default function TotalAbsencesCard({
                 </Text>
               )}
             </Box>
-            <VStack align="flex-start">
+            <VStack align="flex-start" pr="32px">
               <HStack>
                 <Box
                   w="16px"


### PR DESCRIPTION
# Notion Ticket

[NITS](https://www.notion.so/uwblueprintexecs/NITS-1c110f3fb1dc8006beccfb7b405730e2?pvs=4)

## Summary & Review Focus

Addresses
> Default padding should ideally not have scroll bars

Previous version of code specified vertical scrollbars.
Now, we hide vertical overflown content and display scrollbars for horizontal overflow content
## Testing Instructions

1. <!-- List steps to verify the changes -->

## Checklist

- [ ] PR title is descriptive and in imperative tense
- [ ] Commit messages are descriptive, atomic, and follow best practices
- [ ] Linter(s) have been run
- [ ] Requested reviews from the PL and relevant team members
