### PR TITLE
address nits: Add support for years in Export

### DIFF
--- a/app/api/getAbsences/absences.ts
+++ b/app/api/getAbsences/absences.ts
@@ -53,6 +53,7 @@ function formDBQuery(fromYear?: number, toYear?: number) {
 
   const hasProvidedDateRange = Boolean(fromYear && toYear);
   if (!hasProvidedDateRange) return baseQuery;
+
   const isValidDateRange =
     Number.isInteger(fromYear) &&
     Number.isInteger(toYear) &&
@@ -61,6 +62,7 @@ function formDBQuery(fromYear?: number, toYear?: number) {
   if (!isValidDateRange) {
     throw new Error(`${fromYear} to ${toYear} is an invalid date range.`);
   }
+
   const firstDayOfYear = new Date(`${fromYear}-01-01T00:00:00.000Z`);
   const lastDayOfYear = new Date(`${fromYear}-12-31T23:59:59.999Z`);
 

--- a/app/api/getAbsences/absences.ts
+++ b/app/api/getAbsences/absences.ts
@@ -57,7 +57,7 @@ function formDBQuery(fromYear?: number, toYear?: number) {
   const isValidDateRange =
     Number.isInteger(fromYear) &&
     Number.isInteger(toYear) &&
-    toYear - fromYear === 1;
+    Number(toYear) - Number(fromYear) === 1;
 
   if (!isValidDateRange) {
     throw new Error(`${fromYear} to ${toYear} is an invalid date range.`);

--- a/app/api/getAbsences/absences.ts
+++ b/app/api/getAbsences/absences.ts
@@ -77,13 +77,10 @@ function formDBQuery(fromYear?: number, toYear?: number) {
   };
 }
 
-export const getAbsencesFromDatabase = async ({
-  fromYear,
-  toYear,
-}: {
-  fromYear?: number;
-  toYear?: number;
-}): Promise<AbsenceAPI[]> => {
+export const getAbsencesFromDatabase = async (
+  fromYear?: number,
+  toYear?: number
+): Promise<AbsenceAPI[]> => {
   try {
     const query = formDBQuery(fromYear, toYear);
     const absences = await prisma.absence.findMany(query);

--- a/app/api/getAbsences/absences.ts
+++ b/app/api/getAbsences/absences.ts
@@ -1,57 +1,90 @@
 import { prisma } from '@utils/prisma';
 import { AbsenceAPI } from '@utils/types';
 
-export const getAbsencesFromDatabase = async (): Promise<AbsenceAPI[]> => {
-  try {
-    const absences = await prisma.absence.findMany({
-      select: {
-        id: true,
-        lessonDate: true,
-        lessonPlan: true,
-        reasonOfAbsence: true,
-        notes: true,
-        roomNumber: true,
-        absentTeacher: {
-          select: {
-            id: true,
-            firstName: true,
-            lastName: true,
-            profilePicture: true,
-          },
+function formDBQuery(fromYear?: number, toYear?: number) {
+  const baseQuery = {
+    select: {
+      id: true,
+      lessonDate: true,
+      lessonPlan: true,
+      reasonOfAbsence: true,
+      notes: true,
+      roomNumber: true,
+      absentTeacher: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          profilePicture: true,
         },
-        substituteTeacher: {
-          select: {
-            id: true,
-            firstName: true,
-            lastName: true,
-            profilePicture: true,
-          },
+      },
+      substituteTeacher: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          profilePicture: true,
         },
-        location: {
-          select: {
-            id: true,
-            name: true,
-            abbreviation: true,
-            archived: true,
-          },
+      },
+      location: {
+        select: {
+          id: true,
+          name: true,
+          abbreviation: true,
+          archived: true,
         },
+      },
 
-        subject: {
-          select: {
-            id: true,
-            name: true,
-            abbreviation: true,
-            archived: true,
-            colorGroup: {
-              select: {
-                colorCodes: true,
-              },
+      subject: {
+        select: {
+          id: true,
+          name: true,
+          abbreviation: true,
+          archived: true,
+          colorGroup: {
+            select: {
+              colorCodes: true,
             },
           },
         },
       },
-    });
+    },
+  };
 
+  const hasProvidedDateRange = Boolean(fromYear && toYear);
+  if (!hasProvidedDateRange) return baseQuery;
+  const isValidDateRange =
+    Number.isInteger(fromYear) &&
+    Number.isInteger(toYear) &&
+    toYear - fromYear === 1;
+
+  if (!isValidDateRange) {
+    throw new Error(`${fromYear} to ${toYear} is an invalid date range.`);
+  }
+  const firstDayOfYear = new Date(`${fromYear}-01-01T00:00:00.000Z`);
+  const lastDayOfYear = new Date(`${fromYear}-12-31T23:59:59.999Z`);
+
+  return {
+    ...baseQuery,
+    where: {
+      lessonDate: {
+        gte: firstDayOfYear,
+        lte: lastDayOfYear,
+      },
+    },
+  };
+}
+
+export const getAbsencesFromDatabase = async ({
+  fromYear,
+  toYear,
+}: {
+  fromYear?: number;
+  toYear?: number;
+}): Promise<AbsenceAPI[]> => {
+  try {
+    const query = formDBQuery(fromYear, toYear);
+    const absences = await prisma.absence.findMany(query);
     return absences;
   } catch (err) {
     console.error('Error fetching absences:', err);

--- a/app/api/getAbsences/route.ts
+++ b/app/api/getAbsences/route.ts
@@ -1,10 +1,17 @@
 import { AbsenceAPI } from '@utils/types';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getAbsencesFromDatabase } from './absences';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const absences: AbsenceAPI[] = await getAbsencesFromDatabase();
+    const searchParams = request.nextUrl.searchParams;
+    const fromYear = Number(searchParams.get('fromYear'));
+    const toYear = Number(searchParams.get('toYear'));
+
+    const absences: AbsenceAPI[] = await getAbsencesFromDatabase({
+      fromYear,
+      toYear,
+    });
 
     if (!absences.length) {
       return NextResponse.json({ events: [] }, { status: 200 });

--- a/app/api/getAbsences/route.ts
+++ b/app/api/getAbsences/route.ts
@@ -8,10 +8,10 @@ export async function GET(request: NextRequest) {
     const fromYear = Number(searchParams.get('fromYear'));
     const toYear = Number(searchParams.get('toYear'));
 
-    const absences: AbsenceAPI[] = await getAbsencesFromDatabase({
+    const absences: AbsenceAPI[] = await getAbsencesFromDatabase(
       fromYear,
-      toYear,
-    });
+      toYear
+    );
 
     if (!absences.length) {
       return NextResponse.json({ events: [] }, { status: 200 });

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -87,7 +87,7 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           />
         )}
 
-        <ExportAbsencesButton />
+        <ExportAbsencesButton selectedRange={selectedYearRange} />
         <ProfileMenu userData={userData} absenceCap={absenceCap} />
       </HStack>
     </Flex>

--- a/src/components/ExportAbsencesButton.tsx
+++ b/src/components/ExportAbsencesButton.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Text } from '@chakra-ui/react';
 import { useState } from 'react';
 import { FiDownload } from 'react-icons/fi';
 
-const ExportAbsencesButton = () => {
+const ExportAbsencesButton = ({ selectedRange }) => {
   const [error, setError] = useState<string | null>(null);
 
   const convertToCSV = (data: any[]) => {
@@ -41,11 +41,13 @@ const ExportAbsencesButton = () => {
 
     return headers + rows;
   };
-
-  const handleDownload = async () => {
+  const handleDownload = async ({ selectedRange: string }) => {
     try {
       setError(null);
-      const response = await fetch('/api/getAbsences');
+      let [fromYear, toYear] = selectedRange.split('-').map((x) => x.trim());
+      const response = await fetch(
+        `/api/getAbsences?fromYear=${fromYear}&toYear=${toYear}`
+      );
 
       if (!response.ok) {
         throw new Error(`Failed to fetch CSV: ${response.statusText}`);
@@ -79,7 +81,7 @@ const ExportAbsencesButton = () => {
       <Button
         leftIcon={<FiDownload size={18} />}
         variant="solid"
-        onClick={handleDownload}
+        onClick={() => handleDownload({ selectedRange })}
         height="40px"
       >
         Export

--- a/src/components/ExportAbsencesButton.tsx
+++ b/src/components/ExportAbsencesButton.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Text } from '@chakra-ui/react';
 import { useState } from 'react';
 import { FiDownload } from 'react-icons/fi';
 
-const ExportAbsencesButton = ({ selectedRange }) => {
+const ExportAbsencesButton = ({ selectedRange }: { selectedRange: string }) => {
   const [error, setError] = useState<string | null>(null);
 
   const convertToCSV = (data: any[]) => {
@@ -41,7 +41,7 @@ const ExportAbsencesButton = ({ selectedRange }) => {
 
     return headers + rows;
   };
-  const handleDownload = async ({ selectedRange: string }) => {
+  const handleDownload = async () => {
     try {
       setError(null);
       let [fromYear, toYear] = selectedRange.split('-').map((x) => x.trim());
@@ -81,7 +81,7 @@ const ExportAbsencesButton = ({ selectedRange }) => {
       <Button
         leftIcon={<FiDownload size={18} />}
         variant="solid"
-        onClick={() => handleDownload({ selectedRange })}
+        onClick={handleDownload}
         height="40px"
       >
         Export


### PR DESCRIPTION
# Notion Ticket

[NITS](https://www.notion.so/uwblueprintexecs/NITS-1c110f3fb1dc8006beccfb7b405730e2?pvs=4)

## Summary & Review Focus

Addresses:
> The Export tool should only export absences for the current year
Implementation detail:
- added optional query params to the backend API route `/getAbsences`. Now we can pass: `/getAbsences?fromYear=2023&toYear=2024`.
- passed `selectedYearRange` to the ExportAbsencesButton. Used string manipulation to get `fromYear` and `toYear`.


current behaviour of backend API:
- if provided neither `fromYear` nor `toYear` -> behaves as it did before
- if provided only one of `fromYear` and `toYear` -> ignores it & behaves like it did before.
- if provided both of `fromYear` and `toYear`-> does validation & returns absences declared in the `fromYear` 
  - example: 2024-2025 means `00:00 Jan 1st 2024 <= lessonDate  <= 11:59 PM Dec 31st 2024`. We use more precision (seconds & milliseconds) in the actual code.  
  - It uses **UTC time**.
 
## Testing Instructions

- I know I'm **not** using TypeScript well. Please tell me what sort of changes I should make. I'm sorry for being lazy here.
- Does the current behaviour described above make sense? Should I change it?
- Should I not use UTC time? Should I use Toronto time instead?
- 
## Checklist

- [x] PR title is descriptive and in imperative tense
- [ ] Commit messages are descriptive, atomic, and follow best practices
- [ ] Linter(s) have been run
- [ ] Requested reviews from the PL and relevant team members
