### PR TITLE
Add pressed state to email subs

### DIFF
--- a/src/components/dashboard/user_management/EditableSubscriptionsCell.tsx
+++ b/src/components/dashboard/user_management/EditableSubscriptionsCell.tsx
@@ -343,6 +343,7 @@ const EditableSubscriptionsCell: React.FC<EditableSubscriptionsCellProps> = ({
                   display="flex"
                   alignItems="center"
                   _hover={{ bg: 'neutralGray.100' }}
+                  _active={{ bg: 'neutralGray.300' }}
                   onClick={(e) => handleSubjectChange(subject.id, e)}
                   cursor="pointer"
                 >


### PR DESCRIPTION
# Notion Ticket

[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)

## Summary & Review Focus

<!-- Briefly describe the implementation, key changes, and areas needing review -->
(Sorry for the lengthy PR)

Fixes nit:
- [X] There is no press state in the email subscriptions dropdown

* I actually wasn't sure exactly what colour this should be based on the design, so I chose neutral gray 300 to match the year selection dropdown.

## Testing Instructions

1. <!-- List steps to verify the changes -->

## Checklist

- [ ] PR title is descriptive and in imperative tense
- [ ] Commit messages are descriptive, atomic, and follow best practices
- [ ] Linter(s) have been run
- [ ] Requested reviews from the PL and relevant team members
