### PR TITLE
System Options nits

### DIFF
--- a/src/components/dashboard/system_options/EntityTable.tsx
+++ b/src/components/dashboard/system_options/EntityTable.tsx
@@ -10,7 +10,6 @@ import {
   PopoverBody,
   PopoverContent,
   PopoverTrigger,
-  Portal,
   Spacer,
   Text,
   Tooltip,
@@ -494,27 +493,41 @@ const EntityTable: React.FC<EntityTableProps> = ({
                   maxW="60px"
                   maxLength={maxAbbreviationLength}
                 />
-                <HStack>
-                  <Button
-                    variant="outline"
-                    onClick={handleSaveEditedItem}
-                    size="sm"
-                    borderRadius="md"
-                    p={0}
-                    transition="background-color 0.2s ease"
-                  >
-                    <IoCheckmark size={20} color={theme.colors.gray[600]} />
-                  </Button>
-                  <Button
-                    variant="outline"
+                <HStack
+                  spacing={0}
+                  boxShadow="0px 0px 10px 0px rgba(0, 0, 0, 0.15)"
+                  borderRadius="5px"
+                >
+                  <Box
+                    as="button"
+                    p={1}
+                    cursor="pointer"
+                    bg="buttonBackground"
+                    _hover={{ bg: 'neutralGray.100' }}
+                    _active={{ bg: 'neutralGray.300' }}
+                    borderRadius="5px 0 0 5px"
                     onClick={handleCancelEdit}
-                    size="sm"
-                    borderRadius="md"
-                    p={0}
-                    transition="background-color 0.2s ease"
                   >
-                    <IoCloseOutline size={20} color={theme.colors.gray[600]} />
-                  </Button>
+                    <IoCloseOutline
+                      size={24}
+                      color={theme.colors.neutralGray[600]}
+                    />
+                  </Box>
+                  <Box
+                    as="button"
+                    p={1}
+                    cursor="pointer"
+                    bg="buttonBackground"
+                    _hover={{ bg: 'neutralGray.100' }}
+                    _active={{ bg: 'neutralGray.300' }}
+                    borderRadius="0 5px 5px 0"
+                    onClick={handleSaveEditedItem}
+                  >
+                    <IoCheckmark
+                      size={24}
+                      color={theme.colors.neutralGray[600]}
+                    />
+                  </Box>
                 </HStack>
               </Box>
             </>
@@ -870,27 +883,37 @@ const EntityTable: React.FC<EntityTableProps> = ({
               maxW="60px"
               maxLength={maxAbbreviationLength}
             />
-            <HStack>
-              <Button
-                variant="outline"
-                onClick={handleAddItem}
-                size="sm"
-                borderRadius="md"
-                p={0}
-                transition="background-color 0.2s ease"
-              >
-                <IoCheckmark size={20} color={theme.colors.gray[600]} />
-              </Button>
-              <Button
-                variant="outline"
+            <HStack
+              spacing={0}
+              boxShadow="0px 0px 10px 0px rgba(0, 0, 0, 0.15)"
+            >
+              <Box
+                as="button"
+                p={1}
+                cursor="pointer"
+                bg="buttonBackground"
+                _hover={{ bg: 'neutralGray.100' }}
+                _active={{ bg: 'neutralGray.300' }}
+                borderRadius="5px 0 0 5px"
                 onClick={handleCancelEdit}
-                size="sm"
-                borderRadius="md"
-                p={0}
-                transition="background-color 0.2s ease"
               >
-                <IoCloseOutline size={20} color={theme.colors.gray[600]} />
-              </Button>
+                <IoCloseOutline
+                  size={24}
+                  color={theme.colors.neutralGray[600]}
+                />
+              </Box>
+              <Box
+                as="button"
+                p={1}
+                cursor="pointer"
+                bg="buttonBackground"
+                _hover={{ bg: 'neutralGray.100' }}
+                _active={{ bg: 'neutralGray.300' }}
+                borderRadius="0 5px 5px 0"
+                onClick={handleAddItem}
+              >
+                <IoCheckmark size={24} color={theme.colors.neutralGray[600]} />
+              </Box>
             </HStack>
           </Box>
         </Box>

--- a/src/components/dashboard/system_options/EntityTable.tsx
+++ b/src/components/dashboard/system_options/EntityTable.tsx
@@ -650,97 +650,95 @@ const EntityTable: React.FC<EntityTableProps> = ({
                         transition="opacity 0.2s ease"
                       />
                     </PopoverTrigger>
-                    <Portal>
-                      <PopoverContent width="auto" boxShadow="md">
-                        <PopoverBody p={0}>
-                          <VStack align="stretch" spacing={0}>
+                    <PopoverContent width="auto" boxShadow="md">
+                      <PopoverBody p={0}>
+                        <VStack align="stretch" spacing={0}>
+                          <Button
+                            leftIcon={
+                              <FiEdit2
+                                color={theme.colors.neutralGray[600]}
+                                size={15}
+                              />
+                            }
+                            onClick={() => handleEditItem(item)}
+                            variant="ghost"
+                            justifyContent="flex-start"
+                            width="100%"
+                            textStyle="label"
+                            fontSize={12}
+                            color="body"
+                            borderRadius={0}
+                            py={2}
+                          >
+                            Edit
+                          </Button>
+                          <Button
+                            leftIcon={
+                              <FiArchive
+                                color={theme.colors.neutralGray[600]}
+                                size={15}
+                              />
+                            }
+                            onClick={() => handleArchiveItem(item)}
+                            variant="ghost"
+                            justifyContent="flex-start"
+                            width="100%"
+                            textStyle="label"
+                            fontSize={12}
+                            color="body"
+                            borderRadius={0}
+                            py={2}
+                          >
+                            {item.archived ? 'Unarchive' : 'Archive'}
+                          </Button>
+                          <Tooltip
+                            label={
+                              itemsInUse.includes(item.id)
+                                ? `Cannot delete ${entityType} because it is used in existing absences`
+                                : ''
+                            }
+                            isDisabled={!itemsInUse.includes(item.id)}
+                            hasArrow
+                          >
                             <Button
                               leftIcon={
-                                <FiEdit2
+                                <FiTrash2
                                   color={theme.colors.neutralGray[600]}
                                   size={15}
                                 />
                               }
-                              onClick={() => handleEditItem(item)}
+                              onClick={() => handleDeleteItem(item)}
+                              isDisabled={itemsInUse.includes(item.id)}
                               variant="ghost"
                               justifyContent="flex-start"
                               width="100%"
                               textStyle="label"
                               fontSize={12}
                               color="body"
-                              borderRadius={0}
                               py={2}
-                            >
-                              Edit
-                            </Button>
-                            <Button
-                              leftIcon={
-                                <FiArchive
-                                  color={theme.colors.neutralGray[600]}
-                                  size={15}
-                                />
-                              }
-                              onClick={() => handleArchiveItem(item)}
-                              variant="ghost"
-                              justifyContent="flex-start"
-                              width="100%"
-                              textStyle="label"
-                              fontSize={12}
-                              color="body"
                               borderRadius={0}
-                              py={2}
-                            >
-                              {item.archived ? 'Unarchive' : 'Archive'}
-                            </Button>
-                            <Tooltip
-                              label={
+                              bg={
                                 itemsInUse.includes(item.id)
-                                  ? `Cannot delete ${entityType} because it is used in existing absences`
-                                  : ''
+                                  ? 'neutralGray.100'
+                                  : undefined
                               }
-                              isDisabled={!itemsInUse.includes(item.id)}
-                              hasArrow
+                              _hover={
+                                itemsInUse.includes(item.id)
+                                  ? { bg: 'neutralGray.100' }
+                                  : undefined
+                              }
+                              cursor={
+                                itemsInUse.includes(item.id)
+                                  ? 'not-allowed'
+                                  : 'pointer'
+                              }
                             >
-                              <Button
-                                leftIcon={
-                                  <FiTrash2
-                                    color={theme.colors.neutralGray[600]}
-                                    size={15}
-                                  />
-                                }
-                                onClick={() => handleDeleteItem(item)}
-                                isDisabled={itemsInUse.includes(item.id)}
-                                variant="ghost"
-                                justifyContent="flex-start"
-                                width="100%"
-                                textStyle="label"
-                                fontSize={12}
-                                color="body"
-                                py={2}
-                                borderRadius={0}
-                                bg={
-                                  itemsInUse.includes(item.id)
-                                    ? 'neutralGray.100'
-                                    : undefined
-                                }
-                                _hover={
-                                  itemsInUse.includes(item.id)
-                                    ? { bg: 'neutralGray.100' }
-                                    : undefined
-                                }
-                                cursor={
-                                  itemsInUse.includes(item.id)
-                                    ? 'not-allowed'
-                                    : 'pointer'
-                                }
-                              >
-                                Delete
-                              </Button>
-                            </Tooltip>
-                          </VStack>
-                        </PopoverBody>
-                      </PopoverContent>
-                    </Portal>
+                              Delete
+                            </Button>
+                          </Tooltip>
+                        </VStack>
+                      </PopoverBody>
+                    </PopoverContent>
                   </Popover>
                 </Box>
               </Box>

--- a/src/components/dashboard/system_options/EntityTable.tsx
+++ b/src/components/dashboard/system_options/EntityTable.tsx
@@ -886,6 +886,7 @@ const EntityTable: React.FC<EntityTableProps> = ({
             <HStack
               spacing={0}
               boxShadow="0px 0px 10px 0px rgba(0, 0, 0, 0.15)"
+              borderRadius="5px"
             >
               <Box
                 as="button"

--- a/src/components/dashboard/system_options/EntityTable.tsx
+++ b/src/components/dashboard/system_options/EntityTable.tsx
@@ -591,14 +591,44 @@ const EntityTable: React.FC<EntityTableProps> = ({
                 display="flex"
                 justifyContent="space-between"
                 alignItems="center"
+                gap={3}
               >
-                <Text
-                  color={item.archived ? 'text.inactiveButtonText' : 'inherit'}
-                  textStyle="cellBody"
-                  transition="color 0.3s ease"
+                <Tooltip
+                  label={item.abbreviation}
+                  placement="top"
+                  openDelay={300}
+                  isDisabled={item.abbreviation.length <= 3}
+                  hasArrow
                 >
-                  {item.abbreviation}
-                </Text>
+                  <Box position="relative" overflow="hidden" flex={1}>
+                    <Text
+                      color={
+                        item.archived ? 'text.inactiveButtonText' : 'inherit'
+                      }
+                      textStyle="cellBody"
+                      transition="color 0.3s ease"
+                      noOfLines={1}
+                      overflow="hidden"
+                      textOverflow="ellipsis"
+                      whiteSpace="nowrap"
+                      position="relative"
+                      pr="15px"
+                    >
+                      {item.abbreviation}
+                    </Text>
+                    <Box
+                      position="absolute"
+                      right="0"
+                      top="0"
+                      height="100%"
+                      width="15px"
+                      background={`linear-gradient(to right, transparent, ${item.archived ? 'var(--chakra-colors-neutralGray-100)' : 'white'})`}
+                      zIndex="1"
+                      pointerEvents="none"
+                      transition="background 0.3s ease"
+                    />
+                  </Box>
+                </Tooltip>
                 <Box
                   className="action-button"
                   opacity={openMenuId === item.id ? '1' : '0'}


### PR DESCRIPTION
# Notion Ticket

[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)

## Summary & Review Focus

<!-- Briefly describe the implementation, key changes, and areas needing review -->
Fixes nits:
- [ ] System options should not have individual text boxes for check / cancel, it should all be one solid block
- [x] Clicking edit while in system options scrolls you back to the top
- [x] The triple dot position should be essentially fixed and not be pushed to the right if there are too many letters (the letters should fade out instead)
- [x] Everyone on the platform should get enrolled when you make a new email sub
- [x] Display field in the system options fades out characters that are too long when clicking out

## Testing Instructions

1. <!-- List steps to verify the changes -->

## Checklist

- [ ] PR title is descriptive and in imperative tense
- [ ] Commit messages are descriptive, atomic, and follow best practices
- [ ] Linter(s) have been run
- [ ] Requested reviews from the PL and relevant team members
