### PR TITLE
Fix email subs/filtering of archived subjects

### DIFF
--- a/hooks/useUserFiltering.ts
+++ b/hooks/useUserFiltering.ts
@@ -46,8 +46,11 @@ const useUserFiltering = (
       }
 
       if (disabledTags && disabledTags.length > 0) {
-        const userTags =
-          user.mailingLists?.map((list) => list.subject.name) || [];
+        // Get active (non-archived) mailing lists only
+        const activeMailingLists =
+          user.mailingLists?.filter((list) => !list.subject.archived) || [];
+
+        const userTags = activeMailingLists.map((list) => list.subject.name);
 
         if (userTags.length === 0) {
           return !disabledTags.includes(NO_EMAIL_TAGS);

--- a/src/components/dashboard/user_management/EditableSubscriptionsCell.tsx
+++ b/src/components/dashboard/user_management/EditableSubscriptionsCell.tsx
@@ -62,8 +62,12 @@ const EditableSubscriptionsCell: React.FC<EditableSubscriptionsCellProps> = ({
       .map((list) => list.subjectId)
   );
   const [localMailingLists, setLocalMailingLists] = useState<MailingList[]>(
-    mailingLists.filter((list) => !list.subject.archived)
+    () =>
+      [...mailingLists]
+        .filter((list) => !list.subject.archived)
+        .sort((a, b) => a.subjectId - b.subjectId)
   );
+
   const containerRef = useRef<HTMLDivElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLDivElement | null>(null);
@@ -114,14 +118,12 @@ const EditableSubscriptionsCell: React.FC<EditableSubscriptionsCellProps> = ({
   // Update the state when props change
   useEffect(() => {
     if (!isSaving) {
-      setSelectedSubjectIds(
-        mailingLists
-          .filter((list) => !list.subject.archived)
-          .map((list) => list.subjectId)
-      );
-      setLocalMailingLists(
-        mailingLists.filter((list) => !list.subject.archived)
-      );
+      const sorted = [...mailingLists]
+        .filter((list) => !list.subject.archived)
+        .sort((a, b) => a.subjectId - b.subjectId);
+
+      setSelectedSubjectIds(sorted.map((list) => list.subjectId));
+      setLocalMailingLists(sorted);
     }
   }, [mailingLists, isSaving]);
 

--- a/src/components/dashboard/user_management/EditableSubscriptionsCell.tsx
+++ b/src/components/dashboard/user_management/EditableSubscriptionsCell.tsx
@@ -57,10 +57,13 @@ const EditableSubscriptionsCell: React.FC<EditableSubscriptionsCellProps> = ({
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [selectedSubjectIds, setSelectedSubjectIds] = useState<number[]>(
-    mailingLists.map((list) => list.subjectId)
+    mailingLists
+      .filter((list) => !list.subject.archived)
+      .map((list) => list.subjectId)
   );
-  const [localMailingLists, setLocalMailingLists] =
-    useState<MailingList[]>(mailingLists);
+  const [localMailingLists, setLocalMailingLists] = useState<MailingList[]>(
+    mailingLists.filter((list) => !list.subject.archived)
+  );
   const containerRef = useRef<HTMLDivElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/dashboard/user_management/UserManagementCard.tsx
+++ b/src/components/dashboard/user_management/UserManagementCard.tsx
@@ -35,8 +35,13 @@ const UserManagementCard: React.FC<UserManagementCardProps> = ({
         '/api/users?getAbsences=true&getMailingLists=true'
       );
       if (!usersResponse.ok) throw new Error('Failed to fetch users');
-      const usersData = await usersResponse.json();
-      setUsers(usersData);
+      const usersData: UserAPI[] = await usersResponse.json();
+
+      const usersWithSortedLists = usersData.map((u) => ({
+        ...u,
+        mailingLists: sortMailingLists(u.mailingLists || []),
+      }));
+      setUsers(usersWithSortedLists);
 
       const settingsResponse = await fetch('/api/settings');
       if (!settingsResponse.ok) throw new Error('Failed to fetch settings');
@@ -128,7 +133,7 @@ const UserManagementCard: React.FC<UserManagementCardProps> = ({
     if (!user) return;
 
     // Get the complete subject objects for all selected subject IDs
-    const unsortedMailingLists = subjectIds.map((subjectId) => {
+    const updatedMailingLists = subjectIds.map((subjectId) => {
       // Find this subject in our subjects list
       const subjectData = subjects.find((s) => s.id === subjectId);
 
@@ -150,9 +155,6 @@ const UserManagementCard: React.FC<UserManagementCardProps> = ({
         subject: subjectData || user.mailingLists?.[0]?.subject || null,
       };
     });
-
-    // Sort the mailing lists by archived status and ID
-    const updatedMailingLists = sortMailingLists(unsortedMailingLists);
 
     // Optimistically update UI with complete data
     setUsers((prevUsers) =>


### PR DESCRIPTION
# Notion Ticket

[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)

## Summary & Review Focus

<!-- Briefly describe the implementation, key changes, and areas needing review -->
* Fixed issue where archived subjects briefly appeared in the email subs list before being filtered out, due to filtering logic being in a useEffect (fixed by filtering in the initial setting of mailing lists state)
* Filtering no longer considers archived tags (a person only subscribed to archived subjects will show up under "No Email Tags")

## Testing Instructions

1. <!-- List steps to verify the changes -->

## Checklist

- [ ] PR title is descriptive and in imperative tense
- [ ] Commit messages are descriptive, atomic, and follow best practices
- [ ] Linter(s) have been run
- [ ] Requested reviews from the PL and relevant team members
