### PR TITLE
Nit: Add Closing confirmation to Declare Absences

### DIFF
--- a/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
+++ b/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
@@ -31,6 +31,17 @@ interface DeclareAbsenceFormProps {
   initialDate: Date;
   isAdminMode: boolean;
   fetchAbsences: () => Promise<void>;
+  formData: {
+    reasonOfAbsence: string;
+    absentTeacherId: string;
+    substituteTeacherId: string;
+    locationId: string;
+    subjectId: string;
+    roomNumber: string;
+    lessonDate: string;
+    notes: string;
+  };
+  setFormData: any;
 }
 
 const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
@@ -40,6 +51,8 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
   initialDate,
   isAdminMode,
   fetchAbsences,
+  formData,
+  setFormData,
 }) => {
   const showToast = useCustomToast();
   const { isOpen, onOpen, onClose: closeModal } = useDisclosure();
@@ -54,16 +67,6 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
   >(null);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [formData, setFormData] = useState({
-    reasonOfAbsence: '',
-    absentTeacherId: isAdminMode ? '' : String(userId),
-    substituteTeacherId: '',
-    locationId: '',
-    subjectId: '',
-    roomNumber: '',
-    lessonDate: initialDate.toLocaleDateString('en-CA'),
-    notes: '',
-  });
   const [lessonPlan, setLessonPlan] = useState<File | null>(null);
   const [errors, setErrors] = useState<Record<string, string>>({});
 

--- a/src/components/absences/modals/declare/DeclareAbsenceModal.tsx
+++ b/src/components/absences/modals/declare/DeclareAbsenceModal.tsx
@@ -5,8 +5,11 @@ import {
   ModalContent,
   ModalHeader,
   ModalOverlay,
+  useDisclosure,
 } from '@chakra-ui/react';
 import DeclareAbsenceForm from './DeclareAbsenceForm';
+import { useState } from 'react';
+import { UnsavedChangesModal } from './UnsavedChangesModal';
 
 interface DeclareAbsenceModalProps {
   isOpen: boolean;
@@ -26,26 +29,74 @@ const DeclareAbsenceModal: React.FC<DeclareAbsenceModalProps> = ({
   onTabChange,
   isAdminMode,
   fetchAbsences,
-}) => (
-  <Modal isOpen={isOpen} onClose={onClose}>
-    <ModalOverlay />
-    <ModalContent w={362} sx={{ padding: '33px 31px' }} borderRadius="16px">
-      <ModalHeader fontSize={22} p="0 0 28px 0">
-        Declare Absence
-      </ModalHeader>
-      <ModalCloseButton top="33px" right="28px" color="text.header" />
-      <ModalBody p={0}>
-        <DeclareAbsenceForm
-          onClose={onClose}
-          initialDate={initialDate}
-          userId={userId}
-          onTabChange={onTabChange}
-          isAdminMode={isAdminMode}
-          fetchAbsences={fetchAbsences}
-        />
-      </ModalBody>
-    </ModalContent>
-  </Modal>
-);
+}) => {
+  const DefaultFormData = {
+    reasonOfAbsence: '',
+    absentTeacherId: isAdminMode ? '' : String(userId),
+    substituteTeacherId: '',
+    locationId: '',
+    subjectId: '',
+    roomNumber: '',
+    lessonDate: initialDate ? initialDate.toLocaleDateString('en-CA') : '',
+    notes: '',
+  };
+  const [formData, setFormData] = useState(DefaultFormData);
+  const {
+    isOpen: isUnsavedChangesModalOpen,
+    onOpen: openUnsavedChangesModal,
+    onClose: closeUnsavedChangesModal,
+  } = useDisclosure();
+
+  const hasUnsavedChanges = () => {
+    return Object.keys(DefaultFormData).some(
+      (key) =>
+        formData[key as keyof typeof formData] !==
+        DefaultFormData[key as keyof typeof DefaultFormData]
+    );
+  };
+  const handleCloseAttempt = () => {
+    if (hasUnsavedChanges()) {
+      openUnsavedChangesModal();
+    } else {
+      onClose?.();
+    }
+  };
+
+  const handleConfirmClose = () => {
+    closeUnsavedChangesModal();
+    onClose?.();
+  };
+
+  return (
+    <>
+      <UnsavedChangesModal
+        isOpen={isUnsavedChangesModalOpen}
+        onClose={closeUnsavedChangesModal}
+        onConfirm={handleConfirmClose}
+      />
+      <Modal isOpen={isOpen} onClose={handleCloseAttempt}>
+        <ModalOverlay />
+        <ModalContent w={362} sx={{ padding: '33px 31px' }} borderRadius="16px">
+          <ModalHeader fontSize={22} p="0 0 28px 0">
+            Declare Absence
+          </ModalHeader>
+          <ModalCloseButton top="33px" right="28px" color="text.header" />
+          <ModalBody p={0}>
+            <DeclareAbsenceForm
+              onClose={handleCloseAttempt}
+              initialDate={initialDate}
+              userId={userId}
+              onTabChange={onTabChange}
+              isAdminMode={isAdminMode}
+              fetchAbsences={fetchAbsences}
+              formData={formData}
+              setFormData={setFormData}
+            />
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
 
 export default DeclareAbsenceModal;

--- a/src/components/absences/modals/declare/UnsavedChangesModal.tsx
+++ b/src/components/absences/modals/declare/UnsavedChangesModal.tsx
@@ -1,0 +1,43 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  Button,
+} from '@chakra-ui/react';
+
+interface UnsavedChangesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export const UnsavedChangesModal: React.FC<UnsavedChangesModalProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+}) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Unsaved Changes</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          Are you sure you want to close? Any unsaved changes will be lost.
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" mr={3} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button colorScheme="blue" onClick={onConfirm}>
+            Close Anyway
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -413,7 +413,10 @@ const Calendar: React.FC = () => {
       </>
     );
   };
-
+  const onInputFormCloseV2 = () => {
+    console.log('close called from Calendar');
+    onInputFormClose();
+  };
   return (
     <>
       <Global styles={getCalendarStyles} />
@@ -491,7 +494,7 @@ const Calendar: React.FC = () => {
       />
       <DeclareAbsenceModal
         isOpen={isInputFormOpen}
-        onClose={onInputFormClose}
+        onClose={onInputFormCloseV2}
         initialDate={selectedDate!!}
         userId={userData.id}
         onTabChange={setActiveTab}


### PR DESCRIPTION
# Notion Ticket

[Link to NITS page](https://www.notion.so/uwblueprintexecs/NITS-1c110f3fb1dc8006beccfb7b405730e2?pvs=4)

## Summary & Review Focus

I'm requesting a cursory review to first see whether the expected functionality is being met. 
The code is not ideal right now and will need some cleaning up.

Attempts to address: 
> Add Are you sure you want to exit modal when declaring absence has some filled in details

under Declare/Edit/Absence Details Modal
## Testing Instructions

1. <!-- List steps to verify the changes -->

## Checklist

- [ ] PR title is descriptive and in imperative tense
- [ ] Commit messages are descriptive, atomic, and follow best practices
- [ ] Linter(s) have been run
- [ ] Requested reviews from the PL and relevant team members
