### PR TITLE
Tooltip on Truncation

### DIFF
--- a/prisma/seed/.snaplet/dataModel.json
+++ b/prisma/seed/.snaplet/dataModel.json
@@ -24,20 +24,6 @@
           "maxLength": null
         },
         {
-          "id": "public.Absence.absentTeacherId",
-          "name": "absentTeacherId",
-          "columnName": "absentTeacherId",
-          "type": "int4",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.Absence.lessonDate",
           "name": "lessonDate",
           "columnName": "lessonDate",
@@ -56,6 +42,48 @@
           "name": "reasonOfAbsence",
           "columnName": "reasonOfAbsence",
           "type": "text",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Absence.notes",
+          "name": "notes",
+          "columnName": "notes",
+          "type": "text",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Absence.roomNumber",
+          "name": "roomNumber",
+          "columnName": "roomNumber",
+          "type": "text",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Absence.absentTeacherId",
+          "name": "absentTeacherId",
+          "columnName": "absentTeacherId",
+          "type": "int4",
           "isRequired": true,
           "kind": "scalar",
           "isList": false,
@@ -99,34 +127,6 @@
           "columnName": "subjectId",
           "type": "int4",
           "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public.Absence.notes",
-          "name": "notes",
-          "columnName": "notes",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public.Absence.roomNumber",
-          "name": "roomNumber",
-          "columnName": "roomNumber",
-          "type": "text",
-          "isRequired": false,
           "kind": "scalar",
           "isList": false,
           "isGenerated": false,
@@ -675,9 +675,9 @@
       "tableName": "MailingList",
       "fields": [
         {
-          "id": "public.MailingList.subjectId",
-          "name": "subjectId",
-          "columnName": "subjectId",
+          "id": "public.MailingList.userId",
+          "name": "userId",
+          "columnName": "userId",
           "type": "int4",
           "isRequired": true,
           "kind": "scalar",
@@ -689,9 +689,9 @@
           "maxLength": null
         },
         {
-          "id": "public.MailingList.userId",
-          "name": "userId",
-          "columnName": "userId",
+          "id": "public.MailingList.subjectId",
+          "name": "subjectId",
+          "columnName": "subjectId",
           "type": "int4",
           "isRequired": true,
           "kind": "scalar",
@@ -819,20 +819,6 @@
           "maxLength": null
         },
         {
-          "id": "public.Subject.colorGroupId",
-          "name": "colorGroupId",
-          "columnName": "colorGroupId",
-          "type": "int4",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.Subject.archived",
           "name": "archived",
           "columnName": "archived",
@@ -843,6 +829,20 @@
           "isGenerated": false,
           "sequence": false,
           "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Subject.colorGroupId",
+          "name": "colorGroupId",
+          "columnName": "colorGroupId",
+          "type": "int4",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
           "isId": false,
           "maxLength": null
         },
@@ -1019,20 +1019,6 @@
           "maxLength": null
         },
         {
-          "id": "public.User.role",
-          "name": "role",
-          "columnName": "role",
-          "type": "Role",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.User.profilePicture",
           "name": "profilePicture",
           "columnName": "profilePicture",
@@ -1043,6 +1029,20 @@
           "isGenerated": false,
           "sequence": false,
           "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.User.role",
+          "name": "role",
+          "columnName": "role",
+          "type": "Role",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
           "isId": false,
           "maxLength": null
         },
@@ -1215,132 +1215,6 @@
         {
           "name": "_MailingLists_AB_pkey",
           "fields": ["A", "B"],
-          "nullNotDistinct": false
-        }
-      ]
-    },
-    "_prisma_migrations": {
-      "id": "public._prisma_migrations",
-      "schemaName": "public",
-      "tableName": "_prisma_migrations",
-      "fields": [
-        {
-          "id": "public._prisma_migrations.id",
-          "name": "id",
-          "columnName": "id",
-          "type": "varchar",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": true,
-          "maxLength": 36
-        },
-        {
-          "id": "public._prisma_migrations.checksum",
-          "name": "checksum",
-          "columnName": "checksum",
-          "type": "varchar",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": 64
-        },
-        {
-          "id": "public._prisma_migrations.finished_at",
-          "name": "finished_at",
-          "columnName": "finished_at",
-          "type": "timestamptz",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public._prisma_migrations.migration_name",
-          "name": "migration_name",
-          "columnName": "migration_name",
-          "type": "varchar",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": 255
-        },
-        {
-          "id": "public._prisma_migrations.logs",
-          "name": "logs",
-          "columnName": "logs",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public._prisma_migrations.rolled_back_at",
-          "name": "rolled_back_at",
-          "columnName": "rolled_back_at",
-          "type": "timestamptz",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public._prisma_migrations.started_at",
-          "name": "started_at",
-          "columnName": "started_at",
-          "type": "timestamptz",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public._prisma_migrations.applied_steps_count",
-          "name": "applied_steps_count",
-          "columnName": "applied_steps_count",
-          "type": "int4",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        }
-      ],
-      "uniqueConstraints": [
-        {
-          "name": "_prisma_migrations_pkey",
-          "fields": ["id"],
           "nullNotDistinct": false
         }
       ]

--- a/src/components/calendar/sidebar/Accordion.tsx
+++ b/src/components/calendar/sidebar/Accordion.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
 } from '@chakra-ui/react';
 import { IoChevronDown, IoChevronUp } from 'react-icons/io5';
+import { useEffect, useRef, useState } from 'react';
 
 export interface AccordionItem {
   id: number;
@@ -34,6 +35,16 @@ const Accordion = ({
   toggleOpen,
   toggleItem,
 }: AccordionProps) => {
+  const textRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [tooltipStates, setTooltipStates] = useState<boolean[]>([]);
+
+  useEffect(() => {
+    const newStates = textRefs.current.map((el) =>
+      el ? el.scrollWidth > el.clientWidth : false
+    );
+    setTooltipStates(newStates);
+  }, [items]);
+
   return (
     <Box width="100%">
       <Button
@@ -58,8 +69,8 @@ const Accordion = ({
       <Box px={2} mt={2}>
         <Collapse in={isOpen} animateOpacity>
           <Stack spacing={2} mt={0}>
-            {items.map((item) => {
-              const needsTooltip = item.name.length > 20;
+            {items.map((item, index) => {
+              const needsTooltip = tooltipStates[index];
 
               return (
                 <Flex
@@ -96,6 +107,9 @@ const Accordion = ({
                   >
                     <Box flex="1" position="relative" overflow="hidden">
                       <Text
+                        ref={(el) => {
+                          textRefs.current[index] = el;
+                        }}
                         textStyle="subtitle"
                         color="text.body"
                         width="200px"

--- a/src/components/dashboard/system_options/EntityTable.tsx
+++ b/src/components/dashboard/system_options/EntityTable.tsx
@@ -336,6 +336,22 @@ const EntityTable: React.FC<EntityTableProps> = ({
     };
   }, [editingItem, isAddingItem, newItem, handleAddItem, handleSaveEditedItem]);
 
+  const nameRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const abbreviationRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [nameTooltipStates, setNameTooltipStates] = useState<boolean[]>([]);
+  const [abbrTooltipStates, setAbbrTooltipStates] = useState<boolean[]>([]);
+
+  useEffect(() => {
+    const nameStates = nameRefs.current.map((el) =>
+      el ? el.scrollWidth > el.clientWidth : false
+    );
+    const abbrStates = abbreviationRefs.current.map((el) =>
+      el ? el.scrollWidth > el.clientWidth : false
+    );
+    setNameTooltipStates(nameStates);
+    setAbbrTooltipStates(abbrStates);
+  }, [items]);
+
   return (
     <Box borderWidth="1px" borderRadius="md" overflow="hidden">
       {/* Table Header */}
@@ -446,7 +462,7 @@ const EntityTable: React.FC<EntityTableProps> = ({
       </Box>
 
       {/* Table Rows */}
-      {sortedItems.map((item) => (
+      {sortedItems.map((item, index) => (
         <Box
           px={4}
           py={2}
@@ -656,7 +672,7 @@ const EntityTable: React.FC<EntityTableProps> = ({
                     label={item.name}
                     placement="top"
                     openDelay={300}
-                    isDisabled={item.name.length <= 20}
+                    isDisabled={!nameTooltipStates[index]}
                     hasArrow
                   >
                     <Box
@@ -666,6 +682,9 @@ const EntityTable: React.FC<EntityTableProps> = ({
                       flex={1}
                     >
                       <Text
+                        ref={(el) => {
+                          nameRefs.current[index] = el;
+                        }}
                         color={
                           item.archived ? 'text.inactiveButtonText' : 'inherit'
                         }
@@ -707,11 +726,14 @@ const EntityTable: React.FC<EntityTableProps> = ({
                   label={item.abbreviation}
                   placement="top"
                   openDelay={300}
-                  isDisabled={item.abbreviation.length <= 3}
+                  isDisabled={!abbrTooltipStates[index]}
                   hasArrow
                 >
                   <Box position="relative" overflow="hidden" flex={1}>
                     <Text
+                      ref={(el) => {
+                        abbreviationRefs.current[index] = el;
+                      }}
                       color={
                         item.archived ? 'text.inactiveButtonText' : 'inherit'
                       }


### PR DESCRIPTION
## Notion Ticket

[NITS: Nice to Haves](https://www.notion.so/uwblueprintexecs/NITS-1c110f3fb1dc8006beccfb7b405730e2)

## Summary & Review Focus
Only provide tooltip if text is truncated in:

- Calendar sidebar Accordion (Subjects + Locations)
![image](https://github.com/user-attachments/assets/e8134b53-603a-496a-9076-62a9e7379737)

- SystemOptions EntityTable (Name + Abbreviation for Subjects + Locations)
![image](https://github.com/user-attachments/assets/71518d13-bd7e-4c57-aad8-a3027674f3cc)

<!-- Briefly describe the implementation, key changes, and areas needing review -->

## Testing Instructions

0. Log in with an admin account
1. Add subjects, locations, and abbreviations with names of different lengths:
  a) Short name without truncation
  b) Longest possible name before truncation
  c) Long name with truncation

Test Accordion tooltips
1. Ensure tooltips only appear for truncated names in
  a) Subjects Accordion
  b) Locations Accordion

Test EntityTable tooltips
1. Ensure tooltips only appear for truncated names in
  a) Subject full name
  b) Subject display name
  c) Location full name
  d) Location display name

## Checklist

- [x] PR title is descriptive and in imperative tense
- [x] Commit messages are descriptive, atomic, and follow best practices
- [x] Linter(s) have been run
- [x] Requested reviews from the PL and relevant team members
