### PR TITLE
Match File Upload Border to Design

### DIFF
--- a/prisma/seed/.snaplet/dataModel.json
+++ b/prisma/seed/.snaplet/dataModel.json
@@ -24,6 +24,20 @@
           "maxLength": null
         },
         {
+          "id": "public.Absence.absentTeacherId",
+          "name": "absentTeacherId",
+          "columnName": "absentTeacherId",
+          "type": "int4",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
           "id": "public.Absence.lessonDate",
           "name": "lessonDate",
           "columnName": "lessonDate",
@@ -42,48 +56,6 @@
           "name": "reasonOfAbsence",
           "columnName": "reasonOfAbsence",
           "type": "text",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public.Absence.notes",
-          "name": "notes",
-          "columnName": "notes",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public.Absence.roomNumber",
-          "name": "roomNumber",
-          "columnName": "roomNumber",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public.Absence.absentTeacherId",
-          "name": "absentTeacherId",
-          "columnName": "absentTeacherId",
-          "type": "int4",
           "isRequired": true,
           "kind": "scalar",
           "isList": false,
@@ -127,6 +99,34 @@
           "columnName": "subjectId",
           "type": "int4",
           "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Absence.notes",
+          "name": "notes",
+          "columnName": "notes",
+          "type": "text",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Absence.roomNumber",
+          "name": "roomNumber",
+          "columnName": "roomNumber",
+          "type": "text",
+          "isRequired": false,
           "kind": "scalar",
           "isList": false,
           "isGenerated": false,
@@ -675,9 +675,9 @@
       "tableName": "MailingList",
       "fields": [
         {
-          "id": "public.MailingList.userId",
-          "name": "userId",
-          "columnName": "userId",
+          "id": "public.MailingList.subjectId",
+          "name": "subjectId",
+          "columnName": "subjectId",
           "type": "int4",
           "isRequired": true,
           "kind": "scalar",
@@ -689,9 +689,9 @@
           "maxLength": null
         },
         {
-          "id": "public.MailingList.subjectId",
-          "name": "subjectId",
-          "columnName": "subjectId",
+          "id": "public.MailingList.userId",
+          "name": "userId",
+          "columnName": "userId",
           "type": "int4",
           "isRequired": true,
           "kind": "scalar",
@@ -819,20 +819,6 @@
           "maxLength": null
         },
         {
-          "id": "public.Subject.archived",
-          "name": "archived",
-          "columnName": "archived",
-          "type": "bool",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.Subject.colorGroupId",
           "name": "colorGroupId",
           "columnName": "colorGroupId",
@@ -843,6 +829,20 @@
           "isGenerated": false,
           "sequence": false,
           "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Subject.archived",
+          "name": "archived",
+          "columnName": "archived",
+          "type": "bool",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
           "isId": false,
           "maxLength": null
         },
@@ -1019,20 +1019,6 @@
           "maxLength": null
         },
         {
-          "id": "public.User.profilePicture",
-          "name": "profilePicture",
-          "columnName": "profilePicture",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.User.role",
           "name": "role",
           "columnName": "role",
@@ -1043,6 +1029,20 @@
           "isGenerated": false,
           "sequence": false,
           "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.User.profilePicture",
+          "name": "profilePicture",
+          "columnName": "profilePicture",
+          "type": "text",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
           "isId": false,
           "maxLength": null
         },
@@ -1215,6 +1215,132 @@
         {
           "name": "_MailingLists_AB_pkey",
           "fields": ["A", "B"],
+          "nullNotDistinct": false
+        }
+      ]
+    },
+    "_prisma_migrations": {
+      "id": "public._prisma_migrations",
+      "schemaName": "public",
+      "tableName": "_prisma_migrations",
+      "fields": [
+        {
+          "id": "public._prisma_migrations.id",
+          "name": "id",
+          "columnName": "id",
+          "type": "varchar",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": true,
+          "maxLength": 36
+        },
+        {
+          "id": "public._prisma_migrations.checksum",
+          "name": "checksum",
+          "columnName": "checksum",
+          "type": "varchar",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": 64
+        },
+        {
+          "id": "public._prisma_migrations.finished_at",
+          "name": "finished_at",
+          "columnName": "finished_at",
+          "type": "timestamptz",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public._prisma_migrations.migration_name",
+          "name": "migration_name",
+          "columnName": "migration_name",
+          "type": "varchar",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": 255
+        },
+        {
+          "id": "public._prisma_migrations.logs",
+          "name": "logs",
+          "columnName": "logs",
+          "type": "text",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public._prisma_migrations.rolled_back_at",
+          "name": "rolled_back_at",
+          "columnName": "rolled_back_at",
+          "type": "timestamptz",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public._prisma_migrations.started_at",
+          "name": "started_at",
+          "columnName": "started_at",
+          "type": "timestamptz",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public._prisma_migrations.applied_steps_count",
+          "name": "applied_steps_count",
+          "columnName": "applied_steps_count",
+          "type": "int4",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        }
+      ],
+      "uniqueConstraints": [
+        {
+          "name": "_prisma_migrations_pkey",
+          "fields": ["id"],
           "nullNotDistinct": false
         }
       ]

--- a/prisma/seed/.snaplet/dataModel.json
+++ b/prisma/seed/.snaplet/dataModel.json
@@ -24,20 +24,6 @@
           "maxLength": null
         },
         {
-          "id": "public.Absence.absentTeacherId",
-          "name": "absentTeacherId",
-          "columnName": "absentTeacherId",
-          "type": "int4",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.Absence.lessonDate",
           "name": "lessonDate",
           "columnName": "lessonDate",
@@ -56,6 +42,48 @@
           "name": "reasonOfAbsence",
           "columnName": "reasonOfAbsence",
           "type": "text",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Absence.notes",
+          "name": "notes",
+          "columnName": "notes",
+          "type": "text",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Absence.roomNumber",
+          "name": "roomNumber",
+          "columnName": "roomNumber",
+          "type": "text",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Absence.absentTeacherId",
+          "name": "absentTeacherId",
+          "columnName": "absentTeacherId",
+          "type": "int4",
           "isRequired": true,
           "kind": "scalar",
           "isList": false,
@@ -99,34 +127,6 @@
           "columnName": "subjectId",
           "type": "int4",
           "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public.Absence.notes",
-          "name": "notes",
-          "columnName": "notes",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public.Absence.roomNumber",
-          "name": "roomNumber",
-          "columnName": "roomNumber",
-          "type": "text",
-          "isRequired": false,
           "kind": "scalar",
           "isList": false,
           "isGenerated": false,
@@ -675,9 +675,9 @@
       "tableName": "MailingList",
       "fields": [
         {
-          "id": "public.MailingList.subjectId",
-          "name": "subjectId",
-          "columnName": "subjectId",
+          "id": "public.MailingList.userId",
+          "name": "userId",
+          "columnName": "userId",
           "type": "int4",
           "isRequired": true,
           "kind": "scalar",
@@ -689,9 +689,9 @@
           "maxLength": null
         },
         {
-          "id": "public.MailingList.userId",
-          "name": "userId",
-          "columnName": "userId",
+          "id": "public.MailingList.subjectId",
+          "name": "subjectId",
+          "columnName": "subjectId",
           "type": "int4",
           "isRequired": true,
           "kind": "scalar",
@@ -819,20 +819,6 @@
           "maxLength": null
         },
         {
-          "id": "public.Subject.colorGroupId",
-          "name": "colorGroupId",
-          "columnName": "colorGroupId",
-          "type": "int4",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.Subject.archived",
           "name": "archived",
           "columnName": "archived",
@@ -843,6 +829,20 @@
           "isGenerated": false,
           "sequence": false,
           "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Subject.colorGroupId",
+          "name": "colorGroupId",
+          "columnName": "colorGroupId",
+          "type": "int4",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
           "isId": false,
           "maxLength": null
         },
@@ -1019,20 +1019,6 @@
           "maxLength": null
         },
         {
-          "id": "public.User.role",
-          "name": "role",
-          "columnName": "role",
-          "type": "Role",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.User.profilePicture",
           "name": "profilePicture",
           "columnName": "profilePicture",
@@ -1043,6 +1029,20 @@
           "isGenerated": false,
           "sequence": false,
           "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.User.role",
+          "name": "role",
+          "columnName": "role",
+          "type": "Role",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
           "isId": false,
           "maxLength": null
         },
@@ -1215,132 +1215,6 @@
         {
           "name": "_MailingLists_AB_pkey",
           "fields": ["A", "B"],
-          "nullNotDistinct": false
-        }
-      ]
-    },
-    "_prisma_migrations": {
-      "id": "public._prisma_migrations",
-      "schemaName": "public",
-      "tableName": "_prisma_migrations",
-      "fields": [
-        {
-          "id": "public._prisma_migrations.id",
-          "name": "id",
-          "columnName": "id",
-          "type": "varchar",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": true,
-          "maxLength": 36
-        },
-        {
-          "id": "public._prisma_migrations.checksum",
-          "name": "checksum",
-          "columnName": "checksum",
-          "type": "varchar",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": 64
-        },
-        {
-          "id": "public._prisma_migrations.finished_at",
-          "name": "finished_at",
-          "columnName": "finished_at",
-          "type": "timestamptz",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public._prisma_migrations.migration_name",
-          "name": "migration_name",
-          "columnName": "migration_name",
-          "type": "varchar",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": 255
-        },
-        {
-          "id": "public._prisma_migrations.logs",
-          "name": "logs",
-          "columnName": "logs",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public._prisma_migrations.rolled_back_at",
-          "name": "rolled_back_at",
-          "columnName": "rolled_back_at",
-          "type": "timestamptz",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public._prisma_migrations.started_at",
-          "name": "started_at",
-          "columnName": "started_at",
-          "type": "timestamptz",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public._prisma_migrations.applied_steps_count",
-          "name": "applied_steps_count",
-          "columnName": "applied_steps_count",
-          "type": "int4",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        }
-      ],
-      "uniqueConstraints": [
-        {
-          "name": "_prisma_migrations_pkey",
-          "fields": ["id"],
           "nullNotDistinct": false
         }
       ]

--- a/src/components/absences/FileUpload.tsx
+++ b/src/components/absences/FileUpload.tsx
@@ -137,11 +137,15 @@ export const FileUpload: React.FC<FileUploadProps> = ({
     );
   }
 
+  const dashSize = 9;
+  const gapSize = 6;
+  const offset = 4;
+  const borderColor = '#C5C8D8';
+
   return (
     <>
       <Box
         onClick={handleSwap}
-        border="1px dashed"
         borderColor="outline"
         bg={disabled ? 'neutralGray.50' : 'transparent'}
         opacity={disabled ? 0.6 : 1}
@@ -154,6 +158,48 @@ export const FileUpload: React.FC<FileUploadProps> = ({
         flexDirection="column"
         alignItems="center"
         justifyContent="center"
+        sx={{
+          position: 'relative',
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            inset: 0,
+            background: `
+              /* top border */
+              linear-gradient(to right, 
+                transparent ${offset}px, 
+                ${borderColor} ${offset}px, 
+                ${borderColor} ${offset + dashSize}px, 
+                transparent ${offset + dashSize}px
+              ) top left / ${dashSize + gapSize}px 1px repeat-x,
+              
+              /* bottom border */
+              linear-gradient(to right, 
+                transparent ${offset}px, 
+                ${borderColor} ${offset}px, 
+                ${borderColor} ${offset + dashSize}px, 
+                transparent ${offset + dashSize}px
+              ) bottom left / ${dashSize + gapSize}px 1px repeat-x,
+              
+              /* left border */
+              linear-gradient(to bottom, 
+                transparent ${offset}px, 
+                ${borderColor} ${offset}px, 
+                ${borderColor} ${offset + dashSize}px, 
+                transparent ${offset + dashSize}px
+              ) top left / 1px ${dashSize + gapSize}px repeat-y,
+              
+              /* right border */
+              linear-gradient(to bottom, 
+                transparent ${offset}px, 
+                ${borderColor} ${offset}px, 
+                ${borderColor} ${offset + dashSize}px, 
+                transparent ${offset + dashSize}px
+              ) top right / 1px ${dashSize + gapSize}px repeat-y
+            `,
+            pointerEvents: 'none',
+          },
+        }}
       >
         <Image src="/images/upload.svg" alt="Upload" width={10} height={10} />
         <Text textStyle="subtitle">Upload PDF</Text>

--- a/src/components/absences/FileUpload.tsx
+++ b/src/components/absences/FileUpload.tsx
@@ -139,7 +139,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
 
   const dashSize = 9;
   const gapSize = 6;
-  const offset = 4;
+  const offsetSize = 4;
   const borderColor = '#C5C8D8';
 
   return (
@@ -167,34 +167,34 @@ export const FileUpload: React.FC<FileUploadProps> = ({
             background: `
               /* top border */
               linear-gradient(to right, 
-                transparent ${offset}px, 
-                ${borderColor} ${offset}px, 
-                ${borderColor} ${offset + dashSize}px, 
-                transparent ${offset + dashSize}px
+                transparent ${offsetSize}px, 
+                ${borderColor} ${offsetSize}px, 
+                ${borderColor} ${offsetSize + dashSize}px, 
+                transparent ${offsetSize + dashSize}px
               ) top left / ${dashSize + gapSize}px 1px repeat-x,
               
               /* bottom border */
               linear-gradient(to right, 
-                transparent ${offset}px, 
-                ${borderColor} ${offset}px, 
-                ${borderColor} ${offset + dashSize}px, 
-                transparent ${offset + dashSize}px
+                transparent ${offsetSize}px, 
+                ${borderColor} ${offsetSize}px, 
+                ${borderColor} ${offsetSize + dashSize}px, 
+                transparent ${offsetSize + dashSize}px
               ) bottom left / ${dashSize + gapSize}px 1px repeat-x,
               
               /* left border */
               linear-gradient(to bottom, 
-                transparent ${offset}px, 
-                ${borderColor} ${offset}px, 
-                ${borderColor} ${offset + dashSize}px, 
-                transparent ${offset + dashSize}px
+                transparent ${offsetSize}px, 
+                ${borderColor} ${offsetSize}px, 
+                ${borderColor} ${offsetSize + dashSize}px, 
+                transparent ${offsetSize + dashSize}px
               ) top left / 1px ${dashSize + gapSize}px repeat-y,
               
               /* right border */
               linear-gradient(to bottom, 
-                transparent ${offset}px, 
-                ${borderColor} ${offset}px, 
-                ${borderColor} ${offset + dashSize}px, 
-                transparent ${offset + dashSize}px
+                transparent ${offsetSize}px, 
+                ${borderColor} ${offsetSize}px, 
+                ${borderColor} ${offsetSize + dashSize}px, 
+                transparent ${offsetSize + dashSize}px
               ) top right / 1px ${dashSize + gapSize}px repeat-y
             `,
             pointerEvents: 'none',


### PR DESCRIPTION
## Notion Ticket

[NITS: Nice to Haves](https://www.notion.so/uwblueprintexecs/NITS-1c110f3fb1dc8006beccfb7b405730e2)

## Summary & Review Focus

- Style UploadFile border to better match the design

Previous:
![image](https://github.com/user-attachments/assets/ec3049d4-6efb-46f4-ada3-064aa9352fdf)

Current:
![image](https://github.com/user-attachments/assets/91df9e8e-6127-46af-9f5d-10f872ddd72e)

Note: I couldn't extract the exact dash, inter-dash gap, and corner gap sizes from the Figma (seems to just have a "dashed" border-style). I've eyeballed them for now, but they can be changed as needed here:

![image](https://github.com/user-attachments/assets/95c65a63-1e79-40f6-92ae-cc5b620403f9)

## Testing Instructions
1. Declare an absence to view the UploadFile component
2. Ensure the UploadFile component matches the design

## Checklist

- [x] PR title is descriptive and in imperative tense
- [x] Commit messages are descriptive, atomic, and follow best practices
- [x] Linter(s) have been run
- [x] Requested reviews from the PL and relevant team members
