### PR TITLE
Style Absence Form Errors

### DIFF
--- a/prisma/seed/.snaplet/dataModel.json
+++ b/prisma/seed/.snaplet/dataModel.json
@@ -24,20 +24,6 @@
           "maxLength": null
         },
         {
-          "id": "public.Absence.absentTeacherId",
-          "name": "absentTeacherId",
-          "columnName": "absentTeacherId",
-          "type": "int4",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.Absence.lessonDate",
           "name": "lessonDate",
           "columnName": "lessonDate",
@@ -56,6 +42,48 @@
           "name": "reasonOfAbsence",
           "columnName": "reasonOfAbsence",
           "type": "text",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Absence.notes",
+          "name": "notes",
+          "columnName": "notes",
+          "type": "text",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Absence.roomNumber",
+          "name": "roomNumber",
+          "columnName": "roomNumber",
+          "type": "text",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Absence.absentTeacherId",
+          "name": "absentTeacherId",
+          "columnName": "absentTeacherId",
+          "type": "int4",
           "isRequired": true,
           "kind": "scalar",
           "isList": false,
@@ -99,34 +127,6 @@
           "columnName": "subjectId",
           "type": "int4",
           "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public.Absence.notes",
-          "name": "notes",
-          "columnName": "notes",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public.Absence.roomNumber",
-          "name": "roomNumber",
-          "columnName": "roomNumber",
-          "type": "text",
-          "isRequired": false,
           "kind": "scalar",
           "isList": false,
           "isGenerated": false,
@@ -675,9 +675,9 @@
       "tableName": "MailingList",
       "fields": [
         {
-          "id": "public.MailingList.subjectId",
-          "name": "subjectId",
-          "columnName": "subjectId",
+          "id": "public.MailingList.userId",
+          "name": "userId",
+          "columnName": "userId",
           "type": "int4",
           "isRequired": true,
           "kind": "scalar",
@@ -689,9 +689,9 @@
           "maxLength": null
         },
         {
-          "id": "public.MailingList.userId",
-          "name": "userId",
-          "columnName": "userId",
+          "id": "public.MailingList.subjectId",
+          "name": "subjectId",
+          "columnName": "subjectId",
           "type": "int4",
           "isRequired": true,
           "kind": "scalar",
@@ -819,20 +819,6 @@
           "maxLength": null
         },
         {
-          "id": "public.Subject.colorGroupId",
-          "name": "colorGroupId",
-          "columnName": "colorGroupId",
-          "type": "int4",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.Subject.archived",
           "name": "archived",
           "columnName": "archived",
@@ -843,6 +829,20 @@
           "isGenerated": false,
           "sequence": false,
           "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.Subject.colorGroupId",
+          "name": "colorGroupId",
+          "columnName": "colorGroupId",
+          "type": "int4",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
           "isId": false,
           "maxLength": null
         },
@@ -1019,20 +1019,6 @@
           "maxLength": null
         },
         {
-          "id": "public.User.role",
-          "name": "role",
-          "columnName": "role",
-          "type": "Role",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.User.profilePicture",
           "name": "profilePicture",
           "columnName": "profilePicture",
@@ -1043,6 +1029,20 @@
           "isGenerated": false,
           "sequence": false,
           "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.User.role",
+          "name": "role",
+          "columnName": "role",
+          "type": "Role",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
           "isId": false,
           "maxLength": null
         },
@@ -1215,132 +1215,6 @@
         {
           "name": "_MailingLists_AB_pkey",
           "fields": ["A", "B"],
-          "nullNotDistinct": false
-        }
-      ]
-    },
-    "_prisma_migrations": {
-      "id": "public._prisma_migrations",
-      "schemaName": "public",
-      "tableName": "_prisma_migrations",
-      "fields": [
-        {
-          "id": "public._prisma_migrations.id",
-          "name": "id",
-          "columnName": "id",
-          "type": "varchar",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": true,
-          "maxLength": 36
-        },
-        {
-          "id": "public._prisma_migrations.checksum",
-          "name": "checksum",
-          "columnName": "checksum",
-          "type": "varchar",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": 64
-        },
-        {
-          "id": "public._prisma_migrations.finished_at",
-          "name": "finished_at",
-          "columnName": "finished_at",
-          "type": "timestamptz",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public._prisma_migrations.migration_name",
-          "name": "migration_name",
-          "columnName": "migration_name",
-          "type": "varchar",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": 255
-        },
-        {
-          "id": "public._prisma_migrations.logs",
-          "name": "logs",
-          "columnName": "logs",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public._prisma_migrations.rolled_back_at",
-          "name": "rolled_back_at",
-          "columnName": "rolled_back_at",
-          "type": "timestamptz",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public._prisma_migrations.started_at",
-          "name": "started_at",
-          "columnName": "started_at",
-          "type": "timestamptz",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "public._prisma_migrations.applied_steps_count",
-          "name": "applied_steps_count",
-          "columnName": "applied_steps_count",
-          "type": "int4",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        }
-      ],
-      "uniqueConstraints": [
-        {
-          "name": "_prisma_migrations_pkey",
-          "fields": ["id"],
           "nullNotDistinct": false
         }
       ]

--- a/src/components/absences/modals/DateOfAbsence.tsx
+++ b/src/components/absences/modals/DateOfAbsence.tsx
@@ -14,7 +14,7 @@ import MiniCalendar from '../../calendar/MiniCalendar';
 
 interface DateOfAbsenceProps {
   dateValue: Date;
-  onDateSelect: (date: Date) => void;
+  onDateSelect: (date: Date | null) => void;
   error?: string;
   label?: string;
 }
@@ -42,6 +42,11 @@ export const DateOfAbsence: React.FC<DateOfAbsenceProps> = ({
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const rawValue = e.target.value.trim();
       setInputValue(rawValue);
+
+      if (rawValue === '') {
+        onDateSelect(null);
+        return;
+      }
 
       if (new RegExp(DATE_PATTERN).test(rawValue)) {
         const parsedDate = new Date(rawValue);

--- a/src/components/absences/modals/DateOfAbsence.tsx
+++ b/src/components/absences/modals/DateOfAbsence.tsx
@@ -13,7 +13,7 @@ import { useCallback, useEffect, useState } from 'react';
 import MiniCalendar from '../../calendar/MiniCalendar';
 
 interface DateOfAbsenceProps {
-  dateValue: Date;
+  dateValue: Date | null;
   onDateSelect: (date: Date | null) => void;
   error?: string;
   label?: string;
@@ -33,9 +33,7 @@ export const DateOfAbsence: React.FC<DateOfAbsenceProps> = ({
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
-    if (dateValue) {
-      setInputValue(dateValue.toLocaleDateString('en-CA'));
-    }
+    setInputValue(dateValue ? dateValue.toLocaleDateString('en-CA') : '');
   }, [dateValue]);
 
   const handleInputChange = useCallback(
@@ -94,7 +92,7 @@ export const DateOfAbsence: React.FC<DateOfAbsenceProps> = ({
         </PopoverTrigger>
         <PopoverContent width="300px" p={2} boxShadow="lg">
           <MiniCalendar
-            initialDate={dateValue}
+            initialDate={dateValue ?? undefined}
             onDateSelect={handleDateSelect}
             selectDate={dateValue}
           />

--- a/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
+++ b/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
@@ -314,6 +314,7 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
     <Box
       as="form"
       onSubmit={handleSubmit}
+      noValidate
       sx={{
         label: { fontSize: '14px', fontWeight: '400' },
       }}

--- a/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
+++ b/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
@@ -299,7 +299,7 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
   const handleDateSelect = (date: Date) => {
     setFormData((prev) => ({
       ...prev,
-      lessonDate: date.toISOString().split('T')[0],
+      lessonDate: date ? date.toISOString().split('T')[0] : '',
     }));
   };
 

--- a/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
+++ b/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
@@ -296,14 +296,21 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
     }
   };
 
-  const handleDateSelect = (date: Date) => {
+  const handleDateSelect = (date: Date | null) => {
     setFormData((prev) => ({
       ...prev,
       lessonDate: date ? date.toISOString().split('T')[0] : '',
     }));
   };
 
-  const selectedDate = new Date(formData.lessonDate + 'T00:00:00');
+  const parsedLessonDate = formData.lessonDate
+    ? new Date(`${formData.lessonDate}T00:00:00`)
+    : null;
+  const dateValue =
+    parsedLessonDate && !isNaN(parsedLessonDate.getTime())
+      ? parsedLessonDate
+      : null;
+  const selectedDate = dateValue ?? new Date();
   const now = new Date();
   const isWithin14Days =
     (selectedDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24) <= 14;
@@ -387,7 +394,7 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
           />
         </FormControl>
         <DateOfAbsence
-          dateValue={initialDate}
+          dateValue={dateValue}
           onDateSelect={handleDateSelect}
           error={errors.lessonDate}
         />

--- a/src/components/absences/modals/edit/EditAbsenceForm.tsx
+++ b/src/components/absences/modals/edit/EditAbsenceForm.tsx
@@ -278,6 +278,7 @@ const EditAbsenceForm: React.FC<EditAbsenceFormProps> = ({
     <Box
       as="form"
       onSubmit={handleSubmit}
+      noValidate
       sx={{ label: { fontSize: '14px', fontWeight: '400' } }}
     >
       <VStack sx={{ gap: '24px' }}>

--- a/src/components/absences/modals/edit/EditAbsenceForm.tsx
+++ b/src/components/absences/modals/edit/EditAbsenceForm.tsx
@@ -229,7 +229,7 @@ const EditAbsenceForm: React.FC<EditAbsenceFormProps> = ({
   const handleDateSelect = (date: Date) => {
     setFormData((prev) => ({
       ...prev,
-      lessonDate: date.toISOString().split('T')[0],
+      lessonDate: date ? date.toISOString().split('T')[0] : '',
     }));
   };
 

--- a/src/components/absences/modals/edit/EditAbsenceForm.tsx
+++ b/src/components/absences/modals/edit/EditAbsenceForm.tsx
@@ -226,12 +226,20 @@ const EditAbsenceForm: React.FC<EditAbsenceFormProps> = ({
     }
   };
 
-  const handleDateSelect = (date: Date) => {
+  const handleDateSelect = (date: Date | null) => {
     setFormData((prev) => ({
       ...prev,
       lessonDate: date ? date.toISOString().split('T')[0] : '',
     }));
   };
+
+  const parsedLessonDate = formData.lessonDate
+    ? new Date(`${formData.lessonDate}T00:00:00`)
+    : null;
+  const dateValue =
+    parsedLessonDate && !isNaN(parsedLessonDate.getTime())
+      ? parsedLessonDate
+      : null;
 
   const handleCloseNotify = () => {
     closeNotify();
@@ -353,7 +361,7 @@ const EditAbsenceForm: React.FC<EditAbsenceFormProps> = ({
         </FormControl>
 
         <DateOfAbsence
-          dateValue={initialData.start}
+          dateValue={dateValue}
           onDateSelect={handleDateSelect}
           error={errors.lessonDate}
         />


### PR DESCRIPTION
## Notion Ticket

[NITS: Nice to Haves](https://www.notion.so/uwblueprintexecs/NITS-1c110f3fb1dc8006beccfb7b405730e2)

## Summary & Review Focus

- Remove browser validation
  - Previously causing the "Please fill out this field" tooltip to appear for the Date and Reason of Absence fields
- Add error handling for when the user manually clears the date field
  - Previously retaining the last-selected date

![image](https://github.com/user-attachments/assets/d442864b-db82-4cd4-8ebf-b209ab8c8dba)

## Testing Instructions
0. Log in with the Sistema Blueprint account (is an admin)

Test DeclareAbsenceForm
1. Attempt to declare an absence with
  a. None of the required fields filled
  b. The required fields filled one by one
  c. The date manually cleared
2. Ensure error messages appear below each missing field + the absence cannot be declared

Test EditAbsenceForm
1. Attempt to edit an absence with
  a. All of the required fields cleared
  b. The required fields cleared one by one
  c. The date manually cleared
2. Ensure error messages appear below each missing field + the absence cannot be edited

## Checklist

- [x] PR title is descriptive and in imperative tense
- [x] Commit messages are descriptive, atomic, and follow best practices
- [x] Linter(s) have been run
- [x] Requested reviews from the PL and relevant team members
