### PR TITLE
change label to p to prevent label click-through onto input

### DIFF
--- a/src/components/absences/modals/AdminTeacherFields.tsx
+++ b/src/components/absences/modals/AdminTeacherFields.tsx
@@ -4,6 +4,7 @@ import {
   FormLabel,
   Text,
 } from '@chakra-ui/react';
+import { useId } from 'react';
 import { SearchDropdown } from './SearchDropdown';
 
 interface AdminTeacherFieldsProps {
@@ -28,14 +29,21 @@ export const AdminTeacherFields: React.FC<AdminTeacherFieldsProps> = ({
   setFormData,
   setErrors,
 }) => {
+  const id = useId();
+
   return (
     <>
       <FormControl isRequired isInvalid={!!errors.absentTeacherId}>
-        <FormLabel htmlFor="absentTeacher" sx={{ display: 'flex' }}>
+        <FormLabel
+          id={'absentTeacherLabel' + id}
+          as="p"
+          sx={{ display: 'flex' }}
+        >
           <Text textStyle="h4">Teacher Absent</Text>
         </FormLabel>
         <SearchDropdown
           id="absentTeacher"
+          ariaLabelledBy={'absentTeacherLabel' + id}
           excludedId={formData.substituteTeacherId}
           defaultValueId={Number(formData.absentTeacherId)}
           onChange={(value) => {
@@ -55,11 +63,16 @@ export const AdminTeacherFields: React.FC<AdminTeacherFieldsProps> = ({
       </FormControl>
 
       <FormControl>
-        <FormLabel htmlFor="substituteTeacher" sx={{ display: 'flex' }}>
+        <FormLabel
+          id={'substituteTeacherLabel' + id}
+          as="p"
+          sx={{ display: 'flex' }}
+        >
           <Text textStyle="h4">Substitute Teacher</Text>
         </FormLabel>
         <SearchDropdown
           id="substituteTeacher"
+          ariaLabelledBy={'substituteTeacherLabel' + id}
           excludedId={formData.absentTeacherId}
           defaultValueId={
             formData.substituteTeacherId

--- a/src/components/absences/modals/DateOfAbsence.tsx
+++ b/src/components/absences/modals/DateOfAbsence.tsx
@@ -68,7 +68,7 @@ export const DateOfAbsence: React.FC<DateOfAbsenceProps> = ({
 
   return (
     <FormControl isRequired isInvalid={!!error}>
-      <FormLabel sx={{ display: 'flex' }}>
+      <FormLabel as="p" id="dateOfAbsenceLabel" sx={{ display: 'flex' }}>
         <Text textStyle="h4">{label}</Text>
       </FormLabel>
       <Popover
@@ -80,6 +80,7 @@ export const DateOfAbsence: React.FC<DateOfAbsenceProps> = ({
         <PopoverTrigger>
           <Box>
             <Input
+              aria-labelledby="dateOfAbsenceLabel"
               value={inputValue}
               onChange={handleInputChange}
               placeholder="YYYY-MM-DD"

--- a/src/components/absences/modals/DateOfAbsence.tsx
+++ b/src/components/absences/modals/DateOfAbsence.tsx
@@ -9,7 +9,7 @@ import {
   PopoverTrigger,
   Text,
 } from '@chakra-ui/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useId } from 'react';
 import MiniCalendar from '../../calendar/MiniCalendar';
 
 interface DateOfAbsenceProps {
@@ -66,9 +66,11 @@ export const DateOfAbsence: React.FC<DateOfAbsenceProps> = ({
     [onDateSelect]
   );
 
+  const id = useId();
+
   return (
     <FormControl isRequired isInvalid={!!error}>
-      <FormLabel as="p" id="dateOfAbsenceLabel" sx={{ display: 'flex' }}>
+      <FormLabel as="p" id={'dateOfAbsenceLabel' + id} sx={{ display: 'flex' }}>
         <Text textStyle="h4">{label}</Text>
       </FormLabel>
       <Popover
@@ -80,7 +82,7 @@ export const DateOfAbsence: React.FC<DateOfAbsenceProps> = ({
         <PopoverTrigger>
           <Box>
             <Input
-              aria-labelledby="dateOfAbsenceLabel"
+              aria-labelledby={'dateOfAbsenceLabel' + id}
               value={inputValue}
               onChange={handleInputChange}
               placeholder="YYYY-MM-DD"

--- a/src/components/absences/modals/InputDropdown.tsx
+++ b/src/components/absences/modals/InputDropdown.tsx
@@ -18,7 +18,7 @@ import { useCustomToast } from '../../CustomToast';
 export type Option = { name: string; id: number };
 
 interface InputDropdownProps {
-  labelledBy: string;
+  ariaLabelledBy: string;
   label: string;
   type: 'location' | 'subject';
   onChange: (value: Option | null) => void;
@@ -26,7 +26,7 @@ interface InputDropdownProps {
 }
 
 export const InputDropdown: React.FC<InputDropdownProps> = ({
-  labelledBy,
+  ariaLabelledBy,
   label,
   type,
   onChange,
@@ -122,7 +122,7 @@ export const InputDropdown: React.FC<InputDropdownProps> = ({
             value={selectedOption ? selectedOption.name : ''}
             readOnly
             _focusVisible={{ outline: 'none' }}
-            aria-labelledby={labelledBy}
+            aria-labelledby={ariaLabelledBy}
           />
           <InputRightElement pointerEvents="none">
             {isOpen ? <IoChevronUp /> : <IoChevronDown />}

--- a/src/components/absences/modals/InputDropdown.tsx
+++ b/src/components/absences/modals/InputDropdown.tsx
@@ -18,6 +18,7 @@ import { useCustomToast } from '../../CustomToast';
 export type Option = { name: string; id: number };
 
 interface InputDropdownProps {
+  labelledBy: string;
   label: string;
   type: 'location' | 'subject';
   onChange: (value: Option | null) => void;
@@ -25,6 +26,7 @@ interface InputDropdownProps {
 }
 
 export const InputDropdown: React.FC<InputDropdownProps> = ({
+  labelledBy,
   label,
   type,
   onChange,
@@ -120,6 +122,7 @@ export const InputDropdown: React.FC<InputDropdownProps> = ({
             value={selectedOption ? selectedOption.name : ''}
             readOnly
             _focusVisible={{ outline: 'none' }}
+            aria-labelledby={labelledBy}
           />
           <InputRightElement pointerEvents="none">
             {isOpen ? <IoChevronUp /> : <IoChevronDown />}

--- a/src/components/absences/modals/SearchDropdown.tsx
+++ b/src/components/absences/modals/SearchDropdown.tsx
@@ -21,6 +21,7 @@ export type Option = { name: string; id: number; profilePicture: string };
 
 interface SearchDropdownProps {
   id: string;
+  ariaLabelledBy: string;
   excludedId?: string;
   defaultValueId?: number;
   onChange: (value: Option | null) => void;
@@ -28,6 +29,7 @@ interface SearchDropdownProps {
 
 export const SearchDropdown: React.FC<SearchDropdownProps> = ({
   id,
+  ariaLabelledBy,
   excludedId,
   defaultValueId,
   onChange,
@@ -174,6 +176,7 @@ export const SearchDropdown: React.FC<SearchDropdownProps> = ({
               id={id}
               name={id}
               ref={inputRef}
+              aria-labelledby={ariaLabelledBy}
               value={searchQuery}
               onChange={isSelected ? undefined : handleSearchChange}
               onClick={() => {

--- a/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
+++ b/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
@@ -337,10 +337,11 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
         )}
 
         <FormControl isRequired isInvalid={!!errors.subjectId}>
-          <FormLabel sx={{ display: 'flex' }}>
+          <FormLabel id="subjectLabel" as="p" sx={{ display: 'flex' }}>
             <Text textStyle="h4">Subject</Text>
           </FormLabel>
           <InputDropdown
+            labelledBy="subjectLabel"
             label="subject"
             type="subject"
             onChange={(value) => {
@@ -360,10 +361,11 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
         </FormControl>
 
         <FormControl isRequired isInvalid={!!errors.locationId}>
-          <FormLabel sx={{ display: 'flex' }}>
+          <FormLabel id="locationLabel" as="p" sx={{ display: 'flex' }}>
             <Text textStyle="h4">Location</Text>
           </FormLabel>
           <InputDropdown
+            labelledBy="locationLabel"
             label="location"
             type="location"
             onChange={(value) => {
@@ -381,11 +383,13 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
           />
           <FormErrorMessage>{errors.locationId}</FormErrorMessage>
         </FormControl>
+
         <FormControl>
-          <FormLabel htmlFor="roomNumber" sx={{ display: 'flex' }}>
+          <FormLabel id="roomNumberLabel" sx={{ display: 'flex' }}>
             <Text textStyle="h4">Room Number</Text>
           </FormLabel>
           <Input
+            aria-labelledby="roomNumberLabel"
             id="roomNumber"
             name="roomNumber"
             placeholder="e.g. 2131"
@@ -393,6 +397,7 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
             onChange={handleChange}
           />
         </FormControl>
+
         <DateOfAbsence
           dateValue={dateValue}
           onDateSelect={handleDateSelect}
@@ -400,10 +405,11 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
         />
 
         <FormControl isRequired isInvalid={!!errors.reasonOfAbsence}>
-          <FormLabel htmlFor="reasonOfAbsence" sx={{ display: 'flex' }}>
+          <FormLabel id="reasonOfAbsenceLabel" sx={{ display: 'flex' }}>
             <Text textStyle="h4">Reason of Absence</Text>
           </FormLabel>
           <Textarea
+            aria-labelledby="reasonOfAbsenceLabel"
             id="reasonOfAbsence"
             name="reasonOfAbsence"
             placeholder="Only visible to admin"
@@ -422,10 +428,11 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
         </FormControl>
 
         <FormControl>
-          <FormLabel htmlFor="notes" sx={{ display: 'flex' }}>
+          <FormLabel id="notesLabel" sx={{ display: 'flex' }}>
             <Text textStyle="h4">Notes</Text>
           </FormLabel>
           <Textarea
+            aria-labelledby="notesLabel"
             id="notes"
             name="notes"
             placeholder="Visible to everyone"

--- a/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
+++ b/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
@@ -14,7 +14,7 @@ import { Absence, Prisma } from '@prisma/client';
 import { formatFullDate } from '@utils/dates';
 import { submitAbsence } from '@utils/submitAbsence';
 import { validateAbsenceForm } from '@utils/validateAbsenceForm';
-import { useState, useId } from 'react';
+import { useId, useState } from 'react';
 import { useCustomToast } from '../../../CustomToast';
 import { FileUpload } from '../../FileUpload';
 import { AdminTeacherFields } from '../AdminTeacherFields';
@@ -340,7 +340,7 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
 
         <FormControl isRequired isInvalid={!!errors.subjectId}>
           <FormLabel id={'subjectLabel' + id} as="p" sx={{ display: 'flex' }}>
-            <Text textStyle="h4"> Subject</Text>
+            <Text textStyle="h4">Subject</Text>
           </FormLabel>
           <InputDropdown
             ariaLabelledBy={'subjectLabel' + id}

--- a/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
+++ b/src/components/absences/modals/declare/DeclareAbsenceForm.tsx
@@ -14,7 +14,7 @@ import { Absence, Prisma } from '@prisma/client';
 import { formatFullDate } from '@utils/dates';
 import { submitAbsence } from '@utils/submitAbsence';
 import { validateAbsenceForm } from '@utils/validateAbsenceForm';
-import { useState } from 'react';
+import { useState, useId } from 'react';
 import { useCustomToast } from '../../../CustomToast';
 import { FileUpload } from '../../FileUpload';
 import { AdminTeacherFields } from '../AdminTeacherFields';
@@ -317,6 +317,8 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
   const isUrgent =
     (selectedDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24) <= 7;
 
+  const id = useId();
+
   return (
     <Box
       as="form"
@@ -337,11 +339,11 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
         )}
 
         <FormControl isRequired isInvalid={!!errors.subjectId}>
-          <FormLabel id="subjectLabel" as="p" sx={{ display: 'flex' }}>
-            <Text textStyle="h4">Subject</Text>
+          <FormLabel id={'subjectLabel' + id} as="p" sx={{ display: 'flex' }}>
+            <Text textStyle="h4"> Subject</Text>
           </FormLabel>
           <InputDropdown
-            labelledBy="subjectLabel"
+            ariaLabelledBy={'subjectLabel' + id}
             label="subject"
             type="subject"
             onChange={(value) => {
@@ -361,11 +363,11 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
         </FormControl>
 
         <FormControl isRequired isInvalid={!!errors.locationId}>
-          <FormLabel id="locationLabel" as="p" sx={{ display: 'flex' }}>
+          <FormLabel id={'locationLabel' + id} as="p" sx={{ display: 'flex' }}>
             <Text textStyle="h4">Location</Text>
           </FormLabel>
           <InputDropdown
-            labelledBy="locationLabel"
+            ariaLabelledBy={'locationLabel' + id}
             label="location"
             type="location"
             onChange={(value) => {
@@ -385,11 +387,11 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
         </FormControl>
 
         <FormControl>
-          <FormLabel id="roomNumberLabel" sx={{ display: 'flex' }}>
+          <FormLabel id={'roomNumberLabel' + id} sx={{ display: 'flex' }}>
             <Text textStyle="h4">Room Number</Text>
           </FormLabel>
           <Input
-            aria-labelledby="roomNumberLabel"
+            aria-labelledby={'roomNumberLabel' + id}
             id="roomNumber"
             name="roomNumber"
             placeholder="e.g. 2131"
@@ -405,11 +407,11 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
         />
 
         <FormControl isRequired isInvalid={!!errors.reasonOfAbsence}>
-          <FormLabel id="reasonOfAbsenceLabel" sx={{ display: 'flex' }}>
+          <FormLabel id={'reasonOfAbsenceLabel' + id} sx={{ display: 'flex' }}>
             <Text textStyle="h4">Reason of Absence</Text>
           </FormLabel>
           <Textarea
-            aria-labelledby="reasonOfAbsenceLabel"
+            aria-labelledby={'reasonOfAbsenceLabel' + id}
             id="reasonOfAbsence"
             name="reasonOfAbsence"
             placeholder="Only visible to admin"
@@ -428,11 +430,11 @@ const DeclareAbsenceForm: React.FC<DeclareAbsenceFormProps> = ({
         </FormControl>
 
         <FormControl>
-          <FormLabel id="notesLabel" sx={{ display: 'flex' }}>
+          <FormLabel id={'notesLabel' + id} sx={{ display: 'flex' }}>
             <Text textStyle="h4">Notes</Text>
           </FormLabel>
           <Textarea
-            aria-labelledby="notesLabel"
+            aria-labelledby={'notesLabel' + id}
             id="notes"
             name="notes"
             placeholder="Visible to everyone"

--- a/src/components/absences/modals/edit/EditAbsenceForm.tsx
+++ b/src/components/absences/modals/edit/EditAbsenceForm.tsx
@@ -17,7 +17,7 @@ import { formatFullDate } from '@utils/dates';
 import { submitAbsence } from '@utils/submitAbsence';
 import { EventDetails } from '@utils/types';
 import { validateAbsenceForm } from '@utils/validateAbsenceForm';
-import { useState } from 'react';
+import { useState, useId } from 'react';
 import { IoMailOutline } from 'react-icons/io5';
 import { useCustomToast } from '../../../CustomToast';
 import { FileUpload } from '../../FileUpload';
@@ -282,6 +282,8 @@ const EditAbsenceForm: React.FC<EditAbsenceFormProps> = ({
     }
   };
 
+  const id = useId();
+
   return (
     <Box
       as="form"
@@ -300,11 +302,11 @@ const EditAbsenceForm: React.FC<EditAbsenceFormProps> = ({
         )}
 
         <FormControl isRequired isInvalid={!!errors.subjectId}>
-          <FormLabel id="subjectLabel" as="p" sx={{ display: 'flex' }}>
+          <FormLabel id={'subjectLabel' + id} as="p" sx={{ display: 'flex' }}>
             <Text textStyle="h4">Subject</Text>
           </FormLabel>
           <InputDropdown
-            labelledBy="subjectLabel"
+            ariaLabelledBy={'subjectLabel' + id}
             label="subject"
             type="subject"
             onChange={(value) => {
@@ -325,11 +327,11 @@ const EditAbsenceForm: React.FC<EditAbsenceFormProps> = ({
         </FormControl>
 
         <FormControl isRequired isInvalid={!!errors.locationId}>
-          <FormLabel id="locationLabel" as="p" sx={{ display: 'flex' }}>
+          <FormLabel id={'locationLabel' + id} as="p" sx={{ display: 'flex' }}>
             <Text textStyle="h4">Location</Text>
           </FormLabel>
           <InputDropdown
-            labelledBy="locationLabel"
+            ariaLabelledBy={'locationLabel' + id}
             label="location"
             type="location"
             onChange={(value) => {
@@ -350,10 +352,11 @@ const EditAbsenceForm: React.FC<EditAbsenceFormProps> = ({
         </FormControl>
 
         <FormControl>
-          <FormLabel htmlFor="roomNumber" sx={{ display: 'flex' }}>
+          <FormLabel id={'roomNumberLabel' + id} sx={{ display: 'flex' }}>
             <Text textStyle="h4">Room Number</Text>
           </FormLabel>
           <Input
+            aria-labelledby={'roomNumberLabel' + id}
             id="roomNumber"
             name="roomNumber"
             placeholder="e.g. 2131"
@@ -369,10 +372,11 @@ const EditAbsenceForm: React.FC<EditAbsenceFormProps> = ({
         />
 
         <FormControl isRequired isInvalid={!!errors.reasonOfAbsence}>
-          <FormLabel htmlFor="reasonOfAbsence" sx={{ display: 'flex' }}>
+          <FormLabel id={'reasonOfAbsenceLabel' + id} sx={{ display: 'flex' }}>
             <Text textStyle="h4">Reason of Absence</Text>
           </FormLabel>
           <Textarea
+            aria-labelledby={'reasonOfAbsenceLabel' + id}
             id="reasonOfAbsence"
             name="reasonOfAbsence"
             placeholder="Only visible to admin"
@@ -395,10 +399,11 @@ const EditAbsenceForm: React.FC<EditAbsenceFormProps> = ({
         </FormControl>
 
         <FormControl>
-          <FormLabel htmlFor="notes" sx={{ display: 'flex' }}>
+          <FormLabel id={'notesLabel' + id} sx={{ display: 'flex' }}>
             <Text textStyle="h4">Notes</Text>
           </FormLabel>
           <Textarea
+            aria-labelledby={'notesLabel' + id}
             id="notes"
             name="notes"
             placeholder="Visible to everyone"

--- a/src/components/absences/modals/edit/EditAbsenceForm.tsx
+++ b/src/components/absences/modals/edit/EditAbsenceForm.tsx
@@ -300,10 +300,11 @@ const EditAbsenceForm: React.FC<EditAbsenceFormProps> = ({
         )}
 
         <FormControl isRequired isInvalid={!!errors.subjectId}>
-          <FormLabel sx={{ display: 'flex' }}>
+          <FormLabel id="subjectLabel" as="p" sx={{ display: 'flex' }}>
             <Text textStyle="h4">Subject</Text>
           </FormLabel>
           <InputDropdown
+            labelledBy="subjectLabel"
             label="subject"
             type="subject"
             onChange={(value) => {
@@ -324,10 +325,11 @@ const EditAbsenceForm: React.FC<EditAbsenceFormProps> = ({
         </FormControl>
 
         <FormControl isRequired isInvalid={!!errors.locationId}>
-          <FormLabel sx={{ display: 'flex' }}>
+          <FormLabel id="locationLabel" as="p" sx={{ display: 'flex' }}>
             <Text textStyle="h4">Location</Text>
           </FormLabel>
           <InputDropdown
+            labelledBy="locationLabel"
             label="location"
             type="location"
             onChange={(value) => {


### PR DESCRIPTION
# Notion Ticket

[Clicking the box should open dropdowns/activate the inputs, clicking the text above the dropdowns/input should not](https://www.notion.so/uwblueprintexecs/Clicking-the-box-should-open-dropdowns-activate-the-inputs-clicking-the-text-above-the-dropdowns-in-23e10f3fb1dc80c8a3edf77a94674079)

## Summary & Review Focus

<!-- Briefly describe the implementation, key changes, and areas needing review -->

The "click fowarding" bug occurs because it is built-in to HTML labels, probably for accessibility: https://stackoverflow.com/a/49615087

I am able to change this behaviour by switching the label to be interpreted `as="p"`. To keep accessibility, I added aria-labelledby, which allows screen readers to still pick up on the purpose of the input without the unwanted behaviour.

To verify, run locally and try to click the labels and validate that the dropdowns do not get activated. 

Inputs still work because the fields are still populated correctly:

<img width="1388" height="846" alt="Screenshot 2025-08-19 222206" src="https://github.com/user-attachments/assets/8cfc13fd-590d-4e3f-a6be-502176144145" />

## Checklist

- [x] PR title is descriptive and in imperative tense
- [x] Commit messages are descriptive, atomic, and follow best practices
- [x] Linter(s) have been run
- [x] Requested reviews from the PL and relevant team members
